### PR TITLE
feat(#1): pantalla de login (pasajero y conductor)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +208,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -469,6 +502,15 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -845,6 +887,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,7 +1214,7 @@ dependencies = [
  "js-sys",
  "mime",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.28",
  "rustversion",
  "send_wrapper",
  "serde",
@@ -1705,6 +1765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,6 +2258,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,6 +2328,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "html5ever"
@@ -2311,9 +2402,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3101,8 +3194,11 @@ name = "moto_core"
 version = "0.1.0"
 dependencies = [
  "dioxus",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
+ "tokio",
+ "wiremock",
 ]
 
 [[package]]
@@ -3308,6 +3404,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3967,6 +4073,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -4272,6 +4379,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4328,6 +4447,44 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
 ]
@@ -4416,12 +4573,25 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4435,11 +4605,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5788,6 +5986,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6251,6 +6458,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2024"
 dioxus = { version = "0.7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "webpki-roots"] }

--- a/crates/mobile/src/main.rs
+++ b/crates/mobile/src/main.rs
@@ -1,3 +1,18 @@
+use dioxus::prelude::*;
+use moto_core::api::ApiClient;
+use moto_ui::App;
+
+/// Fallback de desarrollo local. La URL real del backend se inyecta en build
+/// time via la variable de entorno `MOTOYA_API_BASE_URL` (nunca hardcodeada
+/// en el binario para un despliegue real — ver `.claude/STANDARDS.md`).
+const DEFAULT_API_BASE_URL: &str = "http://localhost:8000";
+
 fn main() {
-    dioxus::launch(moto_ui::App);
+    let base_url = option_env!("MOTOYA_API_BASE_URL")
+        .unwrap_or(DEFAULT_API_BASE_URL)
+        .to_string();
+
+    LaunchBuilder::new()
+        .with_context_provider(move || Box::new(ApiClient::new(base_url.clone())))
+        .launch(App);
 }

--- a/crates/moto_core/Cargo.toml
+++ b/crates/moto_core/Cargo.toml
@@ -7,3 +7,8 @@ edition.workspace = true
 dioxus = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
+reqwest.workspace = true
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+wiremock = "0.6"

--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -1,16 +1,114 @@
 //! Cliente HTTP hacia `Back_App_MotoCarros` (`/api/v1`).
 //!
-//! Placeholder de bootstrap: los endpoints reales se agregan issue por issue,
-//! reflejando el contrato que expone el backend en cada momento.
+//! Los endpoints reales se agregan issue por issue, reflejando el contrato
+//! que expone el backend en cada momento (ver `openapi.yaml` de
+//! `Back_App_MotoCarros`).
 
+use crate::models::{ApiErrorBody, AuthenticatedUser, DataEnvelope, LoginPayload};
+
+#[derive(Debug, Clone)]
 pub struct ApiClient {
     pub base_url: String,
+    http: reqwest::Client,
 }
+
+/// Fallos posibles de `POST /api/v1/auth/login`.
+///
+/// `InvalidCredentials` cubre tanto password incorrecta como email
+/// inexistente: el backend responde exactamente el mismo 401 para ambos
+/// casos a proposito (ver `openapi.yaml`), asi que el cliente no puede ni
+/// debe distinguirlos.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LoginError {
+    EmptyFields,
+    InvalidCredentials(String),
+    Validation(ApiErrorBody),
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for LoginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoginError::EmptyFields => write!(f, "Ingresa tu email y tu contrasena."),
+            LoginError::InvalidCredentials(message) => write!(f, "{message}"),
+            LoginError::Validation(body) => write!(f, "{}", body.message),
+            LoginError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            LoginError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for LoginError {}
 
 impl ApiClient {
     pub fn new(base_url: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into(),
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// `POST /api/v1/auth/login`.
+    ///
+    /// No manda ningun rol: el backend lo determina por la cuenta y viaja de
+    /// vuelta en `user.role`.
+    pub async fn login(
+        &self,
+        email: &str,
+        password: &str,
+    ) -> Result<AuthenticatedUser, LoginError> {
+        if email.trim().is_empty() || password.is_empty() {
+            return Err(LoginError::EmptyFields);
+        }
+
+        let url = format!("{}/api/v1/auth/login", self.base_url);
+        let payload = LoginPayload {
+            email: email.to_string(),
+            password: password.to_string(),
+        };
+
+        let response = self
+            .http
+            .post(url)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|err| LoginError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<AuthenticatedUser> = response
+                .json()
+                .await
+                .map_err(|err| LoginError::Network(err.to_string()))?;
+            return Ok(envelope.data);
+        }
+
+        match status.as_u16() {
+            401 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| LoginError::Network(err.to_string()))?;
+                Err(LoginError::InvalidCredentials(body.message))
+            }
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| LoginError::Network(err.to_string()))?;
+                Err(LoginError::Validation(body))
+            }
+            other => Err(LoginError::Unexpected(other)),
         }
     }
 }
@@ -18,10 +116,104 @@ impl ApiClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn new_stores_base_url() {
         let client = ApiClient::new("https://api.example.com");
         assert_eq!(client.base_url, "https://api.example.com");
+    }
+
+    #[tokio::test]
+    async fn login_rejects_empty_fields_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client.login("", "secret").await,
+            Err(LoginError::EmptyFields)
+        );
+        assert_eq!(
+            client.login("ana@example.com", "").await,
+            Err(LoginError::EmptyFields)
+        );
+        assert_eq!(
+            client.login("   ", "secret").await,
+            Err(LoginError::EmptyFields)
+        );
+    }
+
+    #[tokio::test]
+    async fn login_returns_authenticated_user_on_success() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/login"))
+            .and(body_json(serde_json::json!({
+                "email": "ana@example.com",
+                "password": "motoya2026",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "user": {
+                        "id": 1,
+                        "name": "Ana Garcia",
+                        "email": "ana@example.com",
+                        "phone": "+573001234567",
+                        "role": "passenger",
+                    },
+                    "token": {
+                        "access_token": "jwt-token",
+                        "token_type": "bearer",
+                        "expires_in": 900,
+                    },
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let authenticated = client.login("ana@example.com", "motoya2026").await.unwrap();
+
+        assert_eq!(authenticated.user.email, "ana@example.com");
+        assert_eq!(authenticated.token.access_token, "jwt-token");
+    }
+
+    #[tokio::test]
+    async fn login_returns_invalid_credentials_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/login"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El email o la contrasena no son correctos.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .login("ana@example.com", "wrong-password")
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            LoginError::InvalidCredentials(
+                "El email o la contrasena no son correctos.".to_string()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn login_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .login("ana@example.com", "motoya2026")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, LoginError::Network(_)));
     }
 }

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -3,9 +3,108 @@
 //! Se completan a medida que se implementan los issues correspondientes — no
 //! se inventan campos que el backend no exponga todavia.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
+/// Rol de autenticacion de la cuenta (`openapi.yaml#/components/schemas/User`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    Passenger,
+    Driver,
+}
+
+/// `openapi.yaml#/components/schemas/User`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct User {
+    pub id: u64,
+    pub name: String,
+    pub email: String,
+    pub phone: String,
+    pub role: Role,
+}
+
+/// `openapi.yaml#/components/schemas/AuthToken`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AuthToken {
-    pub token: String,
+    pub access_token: String,
+    pub token_type: String,
+    pub expires_in: Option<u64>,
+}
+
+/// `openapi.yaml#/components/schemas/AuthenticatedUser` — respuesta comun del
+/// login y del registro.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AuthenticatedUser {
+    pub user: User,
+    pub token: AuthToken,
+}
+
+/// Envelope `{ "data": ... }` que agregan los API Resources de Laravel en el
+/// nivel superior de la respuesta (ver `.claude/STANDARDS.md` de
+/// `Back_App_MotoCarros`).
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct DataEnvelope<T> {
+    pub data: T,
+}
+
+/// `openapi.yaml#/components/schemas/Error` — formato de error del exception
+/// handler de Laravel.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ApiErrorBody {
+    pub message: String,
+    #[serde(default)]
+    pub errors: Option<HashMap<String, Vec<String>>>,
+}
+
+/// Body de `POST /api/v1/auth/login`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct LoginPayload {
+    pub email: String,
+    pub password: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_authenticated_user_envelope() {
+        let json = r#"{
+            "data": {
+                "user": {
+                    "id": 1,
+                    "name": "Ana Garcia",
+                    "email": "ana@example.com",
+                    "phone": "+573001234567",
+                    "role": "passenger"
+                },
+                "token": {
+                    "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9",
+                    "token_type": "bearer",
+                    "expires_in": 900
+                }
+            }
+        }"#;
+
+        let envelope: DataEnvelope<AuthenticatedUser> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(envelope.data.user.role, Role::Passenger);
+        assert_eq!(
+            envelope.data.token.access_token,
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+        );
+        assert_eq!(envelope.data.token.expires_in, Some(900));
+    }
+
+    #[test]
+    fn deserializes_error_body_without_errors_field() {
+        let json = r#"{"message": "El email o la contrasena no son correctos."}"#;
+
+        let error: ApiErrorBody = serde_json::from_str(json).unwrap();
+
+        assert_eq!(error.message, "El email o la contrasena no son correctos.");
+        assert!(error.errors.is_none());
+    }
 }

--- a/crates/moto_core/src/state.rs
+++ b/crates/moto_core/src/state.rs
@@ -1,18 +1,50 @@
 //! Signals/stores de Dioxus agnosticos de plataforma, expuestos a `moto_ui`
 //! via props o contexto.
+//!
+//! El JWT se guarda unicamente en memoria (este signal vive mientras la app
+//! esta abierta). Sobrevivir a un reinicio de la app es una decision de
+//! storage seguro por plataforma (web vs. movil) que no forma parte de este
+//! issue — ver `.claude/CLAUDE.md` del issue #1.
 
 use dioxus::prelude::*;
 
+use crate::models::{AuthToken, AuthenticatedUser, User};
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SessionState {
-    pub is_authenticated: Signal<bool>,
+    user: Signal<Option<User>>,
+    token: Signal<Option<AuthToken>>,
 }
 
 impl SessionState {
     pub fn new() -> Self {
         Self {
-            is_authenticated: Signal::new(false),
+            user: Signal::new(None),
+            token: Signal::new(None),
         }
+    }
+
+    pub fn is_authenticated(&self) -> bool {
+        self.token.read().is_some()
+    }
+
+    pub fn user(&self) -> Option<User> {
+        self.user.read().clone()
+    }
+
+    pub fn token(&self) -> Option<AuthToken> {
+        self.token.read().clone()
+    }
+
+    /// Guarda la cuenta y el token que devolvio `POST /api/v1/auth/login`.
+    pub fn authenticate(&mut self, authenticated: AuthenticatedUser) {
+        self.user.set(Some(authenticated.user));
+        self.token.set(Some(authenticated.token));
+    }
+
+    pub fn logout(&mut self) {
+        self.user.set(None);
+        self.token.set(None);
     }
 }
 

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -1,11 +1,34 @@
 use dioxus::prelude::*;
+use moto_core::state::SessionState;
 
+pub mod screens;
+
+pub use screens::login::LoginScreen;
+
+/// Raiz de la UI, agnostica de plataforma.
+///
+/// Espera un `moto_core::api::ApiClient` ya inyectado en el contexto por el
+/// binario de plataforma (`web`/`mobile`), con la URL del backend que decida
+/// cada uno — nunca hardcodeada aca (ver `.claude/STANDARDS.md`).
 #[component]
 pub fn App() -> Element {
+    let session = use_context_provider(SessionState::new);
+
+    rsx! {
+        if session.is_authenticated() {
+            Home {}
+        } else {
+            LoginScreen {}
+        }
+    }
+}
+
+#[component]
+fn Home() -> Element {
     rsx! {
         div {
             h1 { "MotoYa" }
-            p { "Frontend en construccion." }
+            p { "Sesion iniciada." }
         }
     }
 }

--- a/crates/moto_ui/src/screens/login.rs
+++ b/crates/moto_ui/src/screens/login.rs
@@ -1,0 +1,80 @@
+//! Pantalla de login (pasajero y conductor) — issue #1.
+//!
+//! El rol no se elige aca: viaja de vuelta en `user.role` dentro de la
+//! respuesta de `POST /api/v1/auth/login`, y es quien use este resultado
+//! (fuera de alcance de este issue) quien decide que UI mostrar despues.
+
+use dioxus::prelude::*;
+use moto_core::api::ApiClient;
+use moto_core::state::SessionState;
+
+#[component]
+pub fn LoginScreen() -> Element {
+    let api_client = use_context::<ApiClient>();
+    let mut session = use_context::<SessionState>();
+
+    let mut email = use_signal(String::new);
+    let mut password = use_signal(String::new);
+    let mut error_message = use_signal(|| None::<String>);
+    let mut is_loading = use_signal(|| false);
+
+    let on_submit = move |event: FormEvent| {
+        event.prevent_default();
+
+        let email_value = email();
+        let password_value = password();
+        let api_client = api_client.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            error_message.set(None);
+
+            match api_client.login(&email_value, &password_value).await {
+                Ok(authenticated) => {
+                    session.authenticate(authenticated);
+                }
+                Err(err) => {
+                    error_message.set(Some(err.to_string()));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    };
+
+    rsx! {
+        div { class: "login-screen",
+            h1 { "Iniciar sesion" }
+            form { onsubmit: on_submit,
+                label { r#for: "login-email", "Email" }
+                input {
+                    id: "login-email",
+                    r#type: "email",
+                    autocomplete: "username",
+                    disabled: is_loading(),
+                    value: "{email}",
+                    oninput: move |event| email.set(event.value()),
+                }
+                label { r#for: "login-password", "Contrasena" }
+                input {
+                    id: "login-password",
+                    r#type: "password",
+                    autocomplete: "current-password",
+                    disabled: is_loading(),
+                    value: "{password}",
+                    oninput: move |event| password.set(event.value()),
+                }
+                button { r#type: "submit", disabled: is_loading(),
+                    if is_loading() {
+                        "Ingresando..."
+                    } else {
+                        "Ingresar"
+                    }
+                }
+            }
+            if let Some(message) = error_message() {
+                p { class: "login-error", role: "alert", "{message}" }
+            }
+        }
+    }
+}

--- a/crates/moto_ui/src/screens/mod.rs
+++ b/crates/moto_ui/src/screens/mod.rs
@@ -1,0 +1,1 @@
+pub mod login;

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -1,3 +1,18 @@
+use dioxus::prelude::*;
+use moto_core::api::ApiClient;
+use moto_ui::App;
+
+/// Fallback de desarrollo local. La URL real del backend se inyecta en build
+/// time via la variable de entorno `MOTOYA_API_BASE_URL` (nunca hardcodeada
+/// en el binario para un despliegue real — ver `.claude/STANDARDS.md`).
+const DEFAULT_API_BASE_URL: &str = "http://localhost:8000";
+
 fn main() {
-    dioxus::launch(moto_ui::App);
+    let base_url = option_env!("MOTOYA_API_BASE_URL")
+        .unwrap_or(DEFAULT_API_BASE_URL)
+        .to_string();
+
+    LaunchBuilder::new()
+        .with_context_provider(move || Box::new(ApiClient::new(base_url.clone())))
+        .launch(App);
 }


### PR DESCRIPTION
Closes #1

## Que hace

Primer flujo de autenticacion del frontend, consumiendo `POST /api/v1/auth/login` del backend (`Back_App_MotoCarros`):

- `moto_core::models`: tipos que reflejan el contrato real del endpoint segun `openapi.yaml` del backend (`User`, `Role`, `AuthToken`, `AuthenticatedUser`, `ApiErrorBody`, envelope `data`). Se ajusto el placeholder `AuthToken` (que solo tenia `token: String`) al shape real: `access_token`, `token_type`, `expires_in`.
- `moto_core::api::ApiClient::login`: llamada HTTP con `reqwest` (rustls, sin OpenSSL nativo) a `POST {base_url}/api/v1/auth/login`. Maneja 200 (éxito), 401 (credenciales invalidas — mismo mensaje generico que usa el backend a proposito para no distinguir password incorrecta de email inexistente), 422 (validacion), y errores de red/conexion. Valida campos vacios antes de mandar el request (sin llamar a la red).
- `moto_core::state::SessionState`: guarda `User`/`AuthToken` en signals de Dioxus tras un login exitoso. Storage **solo en memoria** — sobrevivir a un reinicio de la app queda fuera de alcance de este issue (ver "Decisiones y riesgos").
- `moto_ui::screens::login::LoginScreen`: formulario email/password con estados explicitos de carga, error de credenciales, error de red y validacion de campos vacios (no solo el camino feliz).
- `moto_ui::App`: ahora es la raiz que decide entre `LoginScreen` y una pantalla "Home" placeholder segun `SessionState::is_authenticated()`. Espera un `ApiClient` ya inyectado en contexto (ver decision de `base_url` abajo).
- `web`/`mobile`: usan `dioxus::LaunchBuilder::with_context_provider` para inyectar el `ApiClient` con la URL del backend, en vez de que `moto_ui` la decida.

## Como se probo

- `cargo fmt --all -- --check`, `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`, `cargo test --workspace --exclude mobile`, y `cargo build --package web --target wasm32-unknown-unknown` — todos en verde localmente (mismos comandos que corre `ci.yml`).
- `cargo build --package mobile` compila nativamente.
- Tests en `moto_core` con `wiremock` (HTTP mockeado, no contra el backend real, siguiendo `.claude/STANDARDS.md`): login exitoso con el JSON exacto que devuelve `AuthenticatedUserResource`/`UserResource`/`AuthTokenResource` del backend, credenciales invalidas (401), y error de red (conexion rechazada).
- Verificacion manual en navegador con `dx serve --package web --platform web`: el formulario renderiza con labels accesibles, la validacion de campos vacios muestra "Ingresa tu email y tu contrasena." sin llamar a la red, y con campos llenos (sin backend corriendo) se ve el mensaje de error de red "No se pudo conectar con el servidor. Revisa tu conexion.". No se probo el camino feliz contra un backend real corriendo (ver riesgos).

## Decisiones y riesgos

- **HTTP client**: `reqwest` con `rustls` + `webpki-roots` (en vez de `default-tls`/OpenSSL) para evitar depender de libssl del sistema en el runner de CI y mantener el mismo dependency stack en `wasm32-unknown-unknown` y nativo.
- **Configuracion de `base_url`**: se inyecta via `LaunchBuilder::with_context_provider` desde `web`/`mobile`, leyendo la variable de entorno de build `MOTOYA_API_BASE_URL` con `option_env!` (funciona igual en wasm y nativo, sin acceso a env en runtime del navegador). Fallback de desarrollo local a `http://localhost:8000` — no es una URL de backend real, es el default tipico de `serve` de Laravel, documentado aca en vez de hardcodearse sin mas.
- **Storage del JWT**: solo en memoria (`Signal` de Dioxus dentro de `SessionState`). Persistir la sesion entre reinicios de la app es explicitamente "fuera de alcance" en el issue #1 y queda para un issue aparte que decida el mecanismo por plataforma (web: probablemente storage seguro del navegador: mobile: keychain/keystore).
- **`App` ya no toma `base_url` como prop**: se intento primero pasarlo como prop de componente, pero `dioxus::launch` en 0.7 solo acepta un root `fn() -> Element` sin capturas (no una closure), asi que el patron correcto es inyectar el `ApiClient` completo via contexto desde el binario de plataforma. Esto tambien es mas consistente con `.claude/STANDARDS.md` ("si una pantalla necesita comportamiento distinto por plataforma, esa diferencia vive en `web`/`mobile`, inyectada hacia `ui`").
- No se agrego `dioxus-router` ni ninguna navegacion real: `App` alterna entre `LoginScreen` y un placeholder `Home` unicamente en base a `SessionState`, que es lo minimo necesario para este issue.