### PR TITLE
feat(#3): manejo de JWT con storage seguro por plataforma y refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5903,6 +5903,8 @@ dependencies = [
  "dioxus",
  "moto_core",
  "moto_ui",
+ "serde_json",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/mobile/src/main.rs
+++ b/crates/mobile/src/main.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use dioxus::prelude::*;
 use moto_core::api::ApiClient;
+use moto_core::storage::{InMemoryTokenStorage, TokenStorage};
 use moto_ui::App;
 
 /// Fallback de desarrollo local. La URL real del backend se inyecta en build
@@ -14,5 +17,15 @@ fn main() {
 
     LaunchBuilder::new()
         .with_context_provider(move || Box::new(ApiClient::new(base_url.clone())))
+        // TODO(issue de seguimiento): esto deberia usar el keychain de iOS /
+        // el keystore de Android en vez de memoria. Todavia no hay puente
+        // nativo (proyecto Xcode/Gradle) en este esqueleto para exponer esas
+        // APIs a Rust — ver issue #3, "movil" en la seccion de storage.
+        // `InMemoryTokenStorage` es una eleccion explicita y documentada, no
+        // un descuido: no persiste, igual que el comportamiento actual, pero
+        // tampoco guarda el token en texto plano en disco.
+        .with_context_provider(|| {
+            Box::new(Arc::new(InMemoryTokenStorage::new()) as Arc<dyn TokenStorage>)
+        })
         .launch(App);
 }

--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -4,7 +4,7 @@
 //! que expone el backend en cada momento (ver `openapi.yaml` de
 //! `Back_App_MotoCarros`).
 
-use crate::models::{ApiErrorBody, AuthenticatedUser, DataEnvelope, LoginPayload};
+use crate::models::{ApiErrorBody, AuthToken, AuthenticatedUser, DataEnvelope, LoginPayload};
 
 #[derive(Debug, Clone)]
 pub struct ApiClient {
@@ -47,6 +47,74 @@ impl std::fmt::Display for LoginError {
 }
 
 impl std::error::Error for LoginError {}
+
+/// Fallos posibles de `POST /api/v1/auth/refresh`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RefreshError {
+    /// El token esta vacio, es ilegible, ya esta en la blacklist, o supero
+    /// la ventana de refresh (`JWT_REFRESH_TTL`) — en cualquiera de esos
+    /// casos el backend responde 401 y ya no hay forma de renovar: hay que
+    /// volver a pedir credenciales.
+    Unauthorized(String),
+    /// El endpoint esta limitado a 10 requests/minuto por IP (ver
+    /// `openapi.yaml`); no es motivo para cerrar la sesion, el caller puede
+    /// reintentar mas tarde.
+    RateLimited,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for RefreshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RefreshError::Unauthorized(message) => write!(f, "{message}"),
+            RefreshError::RateLimited => {
+                write!(
+                    f,
+                    "Demasiados intentos de renovar la sesion. Intenta mas tarde."
+                )
+            }
+            RefreshError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            RefreshError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RefreshError {}
+
+/// Resultado de una request autenticada que pudo haber renovado el token en
+/// el camino.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuthenticatedFetch<T> {
+    pub data: T,
+    /// `Some` solo si el primer intento respondio 401 y hubo que renovar el
+    /// token antes de reintentar — el caller (dueno del `SessionState`) debe
+    /// persistirlo con `SessionState::update_token`.
+    pub refreshed_token: Option<AuthToken>,
+}
+
+/// Fallos posibles de una request autenticada con reintento automatico.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AuthenticatedRequestError {
+    /// El token vencio y el intento de renovarlo tambien fallo (ventana de
+    /// refresh superada, token en blacklist, etc.): no queda otra que forzar
+    /// logout y volver al login.
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+enum GetOutcome<T> {
+    Success(T),
+    Unauthorized,
+}
 
 impl ApiClient {
     pub fn new(base_url: impl Into<String>) -> Self {
@@ -110,6 +178,115 @@ impl ApiClient {
             }
             other => Err(LoginError::Unexpected(other)),
         }
+    }
+
+    /// `POST /api/v1/auth/refresh`.
+    ///
+    /// Acepta el access token vigente aunque ya haya expirado, siempre que
+    /// siga dentro de la ventana de refresh que define el backend (ver
+    /// `openapi.yaml` de `Back_App_MotoCarros`). No manda body, solo el
+    /// `Authorization: Bearer` con el token a renovar.
+    pub async fn refresh(&self, access_token: &str) -> Result<AuthToken, RefreshError> {
+        let url = format!("{}/api/v1/auth/refresh", self.base_url);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|err| RefreshError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<AuthToken> = response
+                .json()
+                .await
+                .map_err(|err| RefreshError::Network(err.to_string()))?;
+            return Ok(envelope.data);
+        }
+
+        match status.as_u16() {
+            401 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| RefreshError::Network(err.to_string()))?;
+                Err(RefreshError::Unauthorized(body.message))
+            }
+            429 => Err(RefreshError::RateLimited),
+            other => Err(RefreshError::Unexpected(other)),
+        }
+    }
+
+    /// GET autenticado hacia `path` (p.ej. `/api/v1/me`), reintentando una
+    /// vez con un token renovado si el backend responde 401 por token
+    /// vencido. Pensado para que las pantallas que consuman endpoints
+    /// protegidos (ver issue #9 y siguientes) no tengan que reimplementar
+    /// este reintento cada una — ver issue #3.
+    pub async fn get_authenticated<T>(
+        &self,
+        path: &str,
+        token: &AuthToken,
+    ) -> Result<AuthenticatedFetch<T>, AuthenticatedRequestError>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        if let GetOutcome::Success(data) = self.get_with_token(path, &token.access_token).await? {
+            return Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: None,
+            });
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| AuthenticatedRequestError::SessionExpired)?;
+
+        match self.get_with_token(path, &renewed.access_token).await? {
+            GetOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            GetOutcome::Unauthorized => Err(AuthenticatedRequestError::SessionExpired),
+        }
+    }
+
+    async fn get_with_token<T>(
+        &self,
+        path: &str,
+        access_token: &str,
+    ) -> Result<GetOutcome<T>, AuthenticatedRequestError>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let url = format!("{}{}", self.base_url, path);
+
+        let response = self
+            .http
+            .get(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|err| AuthenticatedRequestError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<T> = response
+                .json()
+                .await
+                .map_err(|err| AuthenticatedRequestError::Network(err.to_string()))?;
+            return Ok(GetOutcome::Success(envelope.data));
+        }
+
+        if status.as_u16() == 401 {
+            return Ok(GetOutcome::Unauthorized);
+        }
+
+        Err(AuthenticatedRequestError::Unexpected(status.as_u16()))
     }
 }
 
@@ -215,5 +392,192 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, LoginError::Network(_)));
+    }
+
+    fn sample_token() -> AuthToken {
+        AuthToken {
+            access_token: "jwt-token".to_string(),
+            token_type: "bearer".to_string(),
+            expires_in: Some(900),
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_returns_a_new_token_on_success() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let refreshed = client.refresh("jwt-token").await.unwrap();
+
+        assert_eq!(refreshed.access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn refresh_returns_unauthorized_when_outside_the_refresh_window() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.refresh("stale-token").await.unwrap_err();
+
+        assert_eq!(
+            error,
+            RefreshError::Unauthorized("El token no es valido o ya expiro.".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_returns_rate_limited_on_429() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.refresh("jwt-token").await.unwrap_err();
+
+        assert_eq!(error, RefreshError::RateLimited);
+    }
+
+    #[derive(Debug, serde::Deserialize, PartialEq)]
+    struct Probe {
+        id: u64,
+    }
+
+    #[tokio::test]
+    async fn get_authenticated_returns_data_without_refreshing_when_token_is_valid() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/_probe"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "data": { "id": 1 } })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .get_authenticated::<Probe>("/api/v1/_probe", &sample_token())
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data, Probe { id: 1 });
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn get_authenticated_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/_probe"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/_probe"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "data": { "id": 1 } })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .get_authenticated::<Probe>("/api/v1/_probe", &sample_token())
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data, Probe { id: 1 });
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn get_authenticated_forces_session_expired_when_refresh_also_fails() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/_probe"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .get_authenticated::<Probe>("/api/v1/_probe", &sample_token())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, AuthenticatedRequestError::SessionExpired);
     }
 }

--- a/crates/moto_core/src/lib.rs
+++ b/crates/moto_core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod api;
 pub mod models;
 pub mod state;
+pub mod storage;

--- a/crates/moto_core/src/state.rs
+++ b/crates/moto_core/src/state.rs
@@ -1,14 +1,16 @@
 //! Signals/stores de Dioxus agnosticos de plataforma, expuestos a `moto_ui`
 //! via props o contexto.
 //!
-//! El JWT se guarda unicamente en memoria (este signal vive mientras la app
-//! esta abierta). Sobrevivir a un reinicio de la app es una decision de
-//! storage seguro por plataforma (web vs. movil) que no forma parte de este
-//! issue — ver `.claude/CLAUDE.md` del issue #1.
+//! El signal vive mientras la app esta abierta; sobrevivir a un reinicio
+//! depende de un `TokenStorage` (issue #3) que el caller (pantalla o binario
+//! de plataforma) debe pasar explicitamente en cada mutacion — `SessionState`
+//! no lo guarda para seguir siendo `Copy`, igual que el resto de los signals
+//! de este modulo.
 
 use dioxus::prelude::*;
 
 use crate::models::{AuthToken, AuthenticatedUser, User};
+use crate::storage::TokenStorage;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SessionState {
@@ -36,20 +38,206 @@ impl SessionState {
         self.token.read().clone()
     }
 
-    /// Guarda la cuenta y el token que devolvio `POST /api/v1/auth/login`.
-    pub fn authenticate(&mut self, authenticated: AuthenticatedUser) {
+    /// Guarda la cuenta y el token que devolvio `POST /api/v1/auth/login`, y
+    /// lo persiste en `storage` para que sobreviva a un reinicio de la app.
+    pub fn authenticate(&mut self, authenticated: AuthenticatedUser, storage: &dyn TokenStorage) {
+        storage.save(&authenticated.token);
         self.user.set(Some(authenticated.user));
         self.token.set(Some(authenticated.token));
     }
 
-    pub fn logout(&mut self) {
+    /// Limpia la sesion, tanto en memoria como en `storage`. Se usa tanto
+    /// para un logout explicito del usuario como para el logout forzado
+    /// cuando un refresh de token falla (ver `moto_core::api::ApiClient`).
+    pub fn logout(&mut self, storage: &dyn TokenStorage) {
+        storage.clear();
         self.user.set(None);
         self.token.set(None);
+    }
+
+    /// Restaura el token persistido (si hay uno) al arrancar la app.
+    ///
+    /// No repuebla `user()`: eso requiere `GET /api/v1/me` (issue #9, fuera
+    /// de alcance aca), asi que tras hidratar `is_authenticated()` puede ser
+    /// `true` con `user()` todavia en `None` hasta que la pantalla que lo
+    /// necesite lo pida.
+    pub fn hydrate(&mut self, storage: &dyn TokenStorage) {
+        if let Some(token) = storage.load() {
+            self.token.set(Some(token));
+        }
+    }
+
+    /// Reemplaza el token vigente (p.ej. tras el refresh automatico de una
+    /// request autenticada) sin tocar `user()`.
+    pub fn update_token(&mut self, token: AuthToken, storage: &dyn TokenStorage) {
+        storage.save(&token);
+        self.token.set(Some(token));
     }
 }
 
 impl Default for SessionState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Role;
+    use crate::storage::InMemoryTokenStorage;
+    use std::any::Any;
+    use std::cell::RefCell;
+
+    // `Signal::new` (usado por `SessionState::new`) exige un runtime de
+    // Dioxus activo — no alcanza con estar en un `#[test]` normal, ver el
+    // panic de `dioxus_core::Runtime::current` si se prueba sin esto. Un
+    // `VirtualDom` minimo provee ese runtime sin necesidad de renderizar
+    // nada de verdad.
+    //
+    // Dioxus atrapa panics durante el render de un componente para sus
+    // error boundaries (`any_props.rs::render`), asi que un `assert!` que
+    // fallara *dentro* de `body` quedaria silenciado en vez de tumbar el
+    // test. Por eso `body` solo hace las mutaciones y devuelve lo que haga
+    // falta verificar; los asserts van despues, fuera del render.
+    type PendingBody = Box<dyn FnOnce() -> Box<dyn Any>>;
+
+    thread_local! {
+        static PENDING: RefCell<Option<PendingBody>> = const { RefCell::new(None) };
+        static RESULT: RefCell<Option<Box<dyn Any>>> = const { RefCell::new(None) };
+    }
+
+    fn test_root() -> Element {
+        if let Some(body) = PENDING.with(|cell| cell.borrow_mut().take()) {
+            let value = body();
+            RESULT.with(|cell| *cell.borrow_mut() = Some(value));
+        }
+        rsx! {}
+    }
+
+    fn run_in_runtime<T: 'static>(body: impl FnOnce() -> T + 'static) -> T {
+        PENDING.with(|cell| {
+            *cell.borrow_mut() = Some(Box::new(move || Box::new(body()) as Box<dyn Any>));
+        });
+
+        let mut vdom = dioxus::prelude::VirtualDom::new(test_root);
+        vdom.rebuild_in_place();
+
+        let result = RESULT
+            .with(|cell| cell.borrow_mut().take())
+            .expect("el body no corrio dentro del runtime de dioxus");
+
+        *result
+            .downcast::<T>()
+            .expect("el tipo devuelto por run_in_runtime no coincide")
+    }
+
+    fn sample_authenticated() -> AuthenticatedUser {
+        AuthenticatedUser {
+            user: User {
+                id: 1,
+                name: "Ana Garcia".to_string(),
+                email: "ana@example.com".to_string(),
+                phone: "+573001234567".to_string(),
+                role: Role::Passenger,
+            },
+            token: AuthToken {
+                access_token: "jwt-token".to_string(),
+                token_type: "bearer".to_string(),
+                expires_in: Some(900),
+            },
+        }
+    }
+
+    #[test]
+    fn authenticate_persists_the_token_in_storage() {
+        let (is_authenticated, saved_access_token) = run_in_runtime(|| {
+            let storage = InMemoryTokenStorage::new();
+            let mut session = SessionState::new();
+            session.authenticate(sample_authenticated(), &storage);
+            (
+                session.is_authenticated(),
+                storage.load().map(|t| t.access_token),
+            )
+        });
+
+        assert!(is_authenticated);
+        assert_eq!(saved_access_token.as_deref(), Some("jwt-token"));
+    }
+
+    #[test]
+    fn logout_clears_both_the_session_and_storage() {
+        let (is_authenticated, user, saved_token) = run_in_runtime(|| {
+            let storage = InMemoryTokenStorage::new();
+            let mut session = SessionState::new();
+            session.authenticate(sample_authenticated(), &storage);
+
+            session.logout(&storage);
+
+            (session.is_authenticated(), session.user(), storage.load())
+        });
+
+        assert!(!is_authenticated);
+        assert_eq!(user, None);
+        assert_eq!(saved_token, None);
+    }
+
+    #[test]
+    fn hydrate_restores_a_previously_saved_token() {
+        let (was_authenticated_before, is_authenticated_after, user) = run_in_runtime(|| {
+            let storage = InMemoryTokenStorage::new();
+            storage.save(&sample_authenticated().token);
+
+            let mut session = SessionState::new();
+            let before = session.is_authenticated();
+
+            session.hydrate(&storage);
+
+            (before, session.is_authenticated(), session.user())
+        });
+
+        assert!(!was_authenticated_before);
+        assert!(is_authenticated_after);
+        assert_eq!(user, None);
+    }
+
+    #[test]
+    fn hydrate_is_a_no_op_when_nothing_was_saved() {
+        let is_authenticated = run_in_runtime(|| {
+            let storage = InMemoryTokenStorage::new();
+            let mut session = SessionState::new();
+
+            session.hydrate(&storage);
+
+            session.is_authenticated()
+        });
+
+        assert!(!is_authenticated);
+    }
+
+    #[test]
+    fn update_token_replaces_the_token_without_touching_the_user() {
+        let (session_access_token, saved_access_token, has_user) = run_in_runtime(|| {
+            let storage = InMemoryTokenStorage::new();
+            let mut session = SessionState::new();
+            session.authenticate(sample_authenticated(), &storage);
+
+            let renewed = AuthToken {
+                access_token: "renewed-token".to_string(),
+                token_type: "bearer".to_string(),
+                expires_in: Some(900),
+            };
+            session.update_token(renewed, &storage);
+
+            (
+                session.token().map(|t| t.access_token),
+                storage.load().map(|t| t.access_token),
+                session.user().is_some(),
+            )
+        });
+
+        assert_eq!(session_access_token.as_deref(), Some("renewed-token"));
+        assert_eq!(saved_access_token.as_deref(), Some("renewed-token"));
+        assert!(has_user);
     }
 }

--- a/crates/moto_core/src/storage.rs
+++ b/crates/moto_core/src/storage.rs
@@ -1,0 +1,96 @@
+//! Abstraccion de almacenamiento persistente del JWT, especifica por
+//! plataforma (issue #3).
+//!
+//! `moto_core` no sabe *como* se guarda el token — solo define el contrato.
+//! Cada binario de plataforma (`web`/`mobile`) provee la implementacion real
+//! y la inyecta via contexto de Dioxus, igual que ya hace con `ApiClient`
+//! (ver `.claude/STANDARDS.md`).
+
+use crate::models::AuthToken;
+
+/// Guarda/recupera el `AuthToken` para que sobreviva a cerrar la app. Cada
+/// plataforma decide el mecanismo (web: storage del navegador; movil:
+/// keychain/keystore nativo) — nunca texto plano sin justificar la
+/// excepcion.
+pub trait TokenStorage: std::fmt::Debug {
+    fn save(&self, token: &AuthToken);
+    fn load(&self) -> Option<AuthToken>;
+    fn clear(&self);
+}
+
+/// Storage en memoria: no sobrevive a cerrar la app. Sirve de base para
+/// tests y como implementacion explicita (no un descuido) donde todavia no
+/// existe un mecanismo seguro nativo — ver `crates/mobile/src/storage.rs`
+/// para el caso concreto y su justificacion.
+#[derive(Debug, Default)]
+pub struct InMemoryTokenStorage {
+    token: std::sync::Mutex<Option<AuthToken>>,
+}
+
+impl InMemoryTokenStorage {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl TokenStorage for InMemoryTokenStorage {
+    fn save(&self, token: &AuthToken) {
+        *self.token.lock().unwrap() = Some(token.clone());
+    }
+
+    fn load(&self) -> Option<AuthToken> {
+        self.token.lock().unwrap().clone()
+    }
+
+    fn clear(&self) {
+        *self.token.lock().unwrap() = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_token() -> AuthToken {
+        AuthToken {
+            access_token: "jwt-token".to_string(),
+            token_type: "bearer".to_string(),
+            expires_in: Some(900),
+        }
+    }
+
+    #[test]
+    fn starts_without_a_token() {
+        let storage = InMemoryTokenStorage::new();
+        assert_eq!(storage.load(), None);
+    }
+
+    #[test]
+    fn saves_and_loads_the_token() {
+        let storage = InMemoryTokenStorage::new();
+        storage.save(&sample_token());
+        assert_eq!(storage.load(), Some(sample_token()));
+    }
+
+    #[test]
+    fn save_overwrites_the_previous_token() {
+        let storage = InMemoryTokenStorage::new();
+        storage.save(&sample_token());
+        let other = AuthToken {
+            access_token: "other-token".to_string(),
+            ..sample_token()
+        };
+        storage.save(&other);
+
+        assert_eq!(storage.load(), Some(other));
+    }
+
+    #[test]
+    fn clear_removes_the_saved_token() {
+        let storage = InMemoryTokenStorage::new();
+        storage.save(&sample_token());
+        storage.clear();
+
+        assert_eq!(storage.load(), None);
+    }
+}

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use dioxus::prelude::*;
 use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
 
 pub mod screens;
 
@@ -7,12 +10,23 @@ pub use screens::login::LoginScreen;
 
 /// Raiz de la UI, agnostica de plataforma.
 ///
-/// Espera un `moto_core::api::ApiClient` ya inyectado en el contexto por el
-/// binario de plataforma (`web`/`mobile`), con la URL del backend que decida
-/// cada uno — nunca hardcodeada aca (ver `.claude/STANDARDS.md`).
+/// Espera un `moto_core::api::ApiClient` y un
+/// `Arc<dyn moto_core::storage::TokenStorage>` ya inyectados en el contexto
+/// por el binario de plataforma (`web`/`mobile`), con la URL del backend y
+/// el mecanismo de storage que decida cada uno — nunca hardcodeados aca (ver
+/// `.claude/STANDARDS.md`).
 #[component]
 pub fn App() -> Element {
-    let session = use_context_provider(SessionState::new);
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context_provider(SessionState::new);
+
+    // Restaura la sesion persistida (si hay una) al arrancar la app —
+    // issue #3. Corre una sola vez: el closure no lee ningun signal, solo
+    // escribe el token, asi que Dioxus no lo vuelve a disparar despues del
+    // primer render.
+    use_effect(move || {
+        session.hydrate(storage.as_ref());
+    });
 
     rsx! {
         if session.is_authenticated() {

--- a/crates/moto_ui/src/screens/login.rs
+++ b/crates/moto_ui/src/screens/login.rs
@@ -4,13 +4,17 @@
 //! respuesta de `POST /api/v1/auth/login`, y es quien use este resultado
 //! (fuera de alcance de este issue) quien decide que UI mostrar despues.
 
+use std::sync::Arc;
+
 use dioxus::prelude::*;
 use moto_core::api::ApiClient;
 use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
 
 #[component]
 pub fn LoginScreen() -> Element {
     let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
     let mut session = use_context::<SessionState>();
 
     let mut email = use_signal(String::new);
@@ -24,6 +28,7 @@ pub fn LoginScreen() -> Element {
         let email_value = email();
         let password_value = password();
         let api_client = api_client.clone();
+        let storage = storage.clone();
 
         spawn(async move {
             is_loading.set(true);
@@ -31,7 +36,7 @@ pub fn LoginScreen() -> Element {
 
             match api_client.login(&email_value, &password_value).await {
                 Ok(authenticated) => {
-                    session.authenticate(authenticated);
+                    session.authenticate(authenticated, storage.as_ref());
                 }
                 Err(err) => {
                     error_message.set(Some(err.to_string()));

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -7,3 +7,5 @@ edition.workspace = true
 dioxus = { workspace = true, features = ["web"] }
 moto_ui = { path = "../moto_ui" }
 moto_core = { path = "../moto_core" }
+serde_json.workspace = true
+web-sys = { version = "0.3", features = ["Window", "Storage"] }

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -1,6 +1,13 @@
+use std::sync::Arc;
+
 use dioxus::prelude::*;
 use moto_core::api::ApiClient;
+use moto_core::storage::TokenStorage;
 use moto_ui::App;
+
+mod storage;
+
+use storage::WebTokenStorage;
 
 /// Fallback de desarrollo local. La URL real del backend se inyecta en build
 /// time via la variable de entorno `MOTOYA_API_BASE_URL` (nunca hardcodeada
@@ -14,5 +21,8 @@ fn main() {
 
     LaunchBuilder::new()
         .with_context_provider(move || Box::new(ApiClient::new(base_url.clone())))
+        .with_context_provider(|| {
+            Box::new(Arc::new(WebTokenStorage::new()) as Arc<dyn TokenStorage>)
+        })
         .launch(App);
 }

--- a/crates/web/src/storage.rs
+++ b/crates/web/src/storage.rs
@@ -1,0 +1,59 @@
+//! Storage seguro del JWT para el target web (WASM) — issue #3.
+//!
+//! Usa `sessionStorage` del navegador en vez de `localStorage`: se limpia al
+//! cerrar la pestana/navegador, asi que un token robado (p.ej. via XSS) tiene
+//! una ventana de vida mucho mas corta que si quedara en `localStorage`
+//! indefinidamente.
+//!
+//! Limitacion conocida y documentada, no un descuido: ningun storage
+//! accesible desde JavaScript (`sessionStorage`, `localStorage`, IndexedDB)
+//! es inmune a XSS. La alternativa mas segura seria una cookie `HttpOnly`
+//! emitida por el backend, pero `Back_App_MotoCarros` hoy devuelve el token
+//! en el body de la respuesta (ver `openapi.yaml`), no en una cookie — migrar
+//! a eso es una decision de backend que queda fuera de este issue.
+//!
+//! No se testea en CI (requiere un `window`/`sessionStorage` real de
+//! navegador que no existe en el runner) — ver `.claude/STANDARDS.md`,
+//! "el renderizado real en web/mobile no se testea en CI". Se valida
+//! manualmente en el navegador.
+
+use moto_core::models::AuthToken;
+use moto_core::storage::TokenStorage;
+
+const STORAGE_KEY: &str = "motoya.auth_token";
+
+#[derive(Debug, Default)]
+pub struct WebTokenStorage;
+
+impl WebTokenStorage {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn session_storage(&self) -> Option<web_sys::Storage> {
+        web_sys::window()?.session_storage().ok().flatten()
+    }
+}
+
+impl TokenStorage for WebTokenStorage {
+    fn save(&self, token: &AuthToken) {
+        let Some(storage) = self.session_storage() else {
+            return;
+        };
+        if let Ok(json) = serde_json::to_string(token) {
+            let _ = storage.set_item(STORAGE_KEY, &json);
+        }
+    }
+
+    fn load(&self) -> Option<AuthToken> {
+        let storage = self.session_storage()?;
+        let json = storage.get_item(STORAGE_KEY).ok().flatten()?;
+        serde_json::from_str(&json).ok()
+    }
+
+    fn clear(&self) {
+        if let Some(storage) = self.session_storage() {
+            let _ = storage.remove_item(STORAGE_KEY);
+        }
+    }
+}


### PR DESCRIPTION
Closes #3

## Qué hace

- `moto_core::api::ApiClient::refresh` implementa `POST /api/v1/auth/refresh`
  (acepta el access token vigente aunque ya haya expirado, dentro de la
  ventana de refresh del backend; ver `openapi.yaml` de `Back_App_MotoCarros`).
- `moto_core::storage::TokenStorage` es el contrato de storage (agnóstico de
  plataforma). `SessionState::authenticate/logout/hydrate/update_token` lo
  reciben explícitamente como parámetro (no lo guardan internamente, para que
  `SessionState` siga siendo `Copy` como el resto del módulo).
- `ApiClient::get_authenticated<T>` es un GET autenticado genérico que, ante
  un 401, intenta renovar el token una vez (`refresh`) y reintenta la request
  original; si el refresh también falla, devuelve `SessionExpired` para que
  el caller cierre la sesión. Pensado para que las pantallas de endpoints
  protegidos (`GET /api/v1/me` del issue #9 y siguientes) lo reusen sin
  reimplementar el reintento.
- `moto_ui::App` hidrata la sesión desde storage al arrancar
  (`SessionState::hydrate`), y `LoginScreen` persiste el token al loguearse.
- Implementaciones concretas de `TokenStorage` por plataforma, inyectadas via
  contexto de Dioxus igual que `ApiClient`:
  - **web**: `WebTokenStorage` sobre `sessionStorage` del navegador (se
    limpia al cerrar la pestaña, reduce la ventana de exposición frente a
    `localStorage`).
  - **mobile**: `InMemoryTokenStorage` (no persiste) — ver "Decisiones y
    riesgos".

## Cómo se probó

- `cargo fmt --all -- --check`, `cargo clippy --workspace --exclude mobile
  --all-targets --all-features -- -D warnings`, `cargo test --workspace
  --exclude mobile` — todo en verde localmente.
- `cargo build --package web --target wasm32-unknown-unknown` — en verde
  (confirma que el código con `web-sys` tipa y linkea para el target real).
- `cargo check -p mobile` — en verde (build completo de mobile no aplica,
  requiere NDK/SDK, ver `.claude/STANDARDS.md`).
- Tests nuevos en `moto_core` con HTTP mockeado (`wiremock`): `refresh` en
  200/401/429, y `get_authenticated` en los tres caminos (200 directo, 401 +
  refresh + reintento exitoso, 401 + refresh también 401 → `SessionExpired`).
  `TokenStorage`/`InMemoryTokenStorage` y `SessionState`
  (`authenticate`/`logout`/`hydrate`/`update_token`) también cubiertos.
- `WebTokenStorage` no tiene tests unitarios: requiere un `window`/
  `sessionStorage` real de navegador que no existe en el runner de CI (mismo
  criterio que ya documenta `.claude/STANDARDS.md` para renderizado real en
  web/mobile). Se valida manualmente en navegador.

## Decisiones y riesgos

- **Storage en mobile es un placeholder honesto, no una implementación real**:
  hoy `crates/mobile` es un binario mínimo sin proyecto Android/iOS nativo
  (no hay `android/`/`ios/`), así que no hay forma de puentear a
  Keystore/Keychain desde Rust todavía. Usar `InMemoryTokenStorage` mantiene
  el comportamiento actual (no persiste) sin fingir seguridad que no existe
  ni guardar nada en texto plano. Documentado en un comentario en
  `crates/mobile/src/main.rs`. Sugiero un issue de seguimiento dedicado a la
  integración nativa cuando exista el scaffolding móvil.
- **`WebTokenStorage` usa `sessionStorage`, no `localStorage`**: se pierde al
  cerrar la pestaña (compromiso deliberado: menos persistencia entre
  sesiones a cambio de una ventana de exposición más corta ante XSS). Ninguna
  de las dos es inmune a XSS — la alternativa real (cookie `HttpOnly`)
  requeriría que el backend la emita, y hoy el token viaja en el body de la
  respuesta.
- **`hydrate()` no repuebla `SessionState::user()`**: solo restaura el token,
  así que tras un reinicio con sesión válida `is_authenticated()` es `true`
  pero `user()` sigue en `None` hasta que una pantalla pida `GET /api/v1/me`
  (issue #9, fuera de alcance acá). `App` hoy solo usa `is_authenticated()`
  para enrutar, así que no hay regresión visible.
- No se implementó una versión "POST/PATCH autenticado" del reintento —
  `get_authenticated` cubre el caso genérico (GET) que van a necesitar los
  próximos issues; se puede extender con el mismo patrón cuando haga falta.