### PR TITLE
feat(#6): registrarme como pasajero

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -4,7 +4,10 @@
 //! que expone el backend en cada momento (ver `openapi.yaml` de
 //! `Back_App_MotoCarros`).
 
-use crate::models::{ApiErrorBody, AuthToken, AuthenticatedUser, DataEnvelope, LoginPayload};
+use crate::models::{
+    ApiErrorBody, AuthToken, AuthenticatedUser, DataEnvelope, LoginPayload,
+    RegisterPassengerPayload,
+};
 
 #[derive(Debug, Clone)]
 pub struct ApiClient {
@@ -47,6 +50,62 @@ impl std::fmt::Display for LoginError {
 }
 
 impl std::error::Error for LoginError {}
+
+/// Fallos posibles de `POST /api/v1/auth/register/passenger`.
+///
+/// `InvalidEmail`/`InvalidPhone` se detectan en el cliente antes de mandar la
+/// request (formato basico), sin duplicar las reglas completas del backend
+/// (unicidad, normalizacion) — esas siguen viajando como `Validation` en un
+/// 422 (ver `openapi.yaml` de `Back_App_MotoCarros`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum RegisterError {
+    EmptyFields,
+    InvalidEmail,
+    InvalidPhone,
+    Validation(ApiErrorBody),
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for RegisterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RegisterError::EmptyFields => write!(f, "Completa todos los campos."),
+            RegisterError::InvalidEmail => write!(f, "Ingresa un email valido."),
+            RegisterError::InvalidPhone => {
+                write!(f, "Ingresa un telefono valido (7 a 15 digitos).")
+            }
+            RegisterError::Validation(body) => write!(f, "{}", body.message),
+            RegisterError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            RegisterError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RegisterError {}
+
+/// Formato basico (no unicidad, eso lo valida el backend): una arroba, con
+/// algo antes y un dominio con un punto despues.
+fn is_valid_email(email: &str) -> bool {
+    let Some((local, domain)) = email.split_once('@') else {
+        return false;
+    };
+    !local.is_empty() && !domain.is_empty() && domain.contains('.') && !email.contains(' ')
+}
+
+/// Formato E.164 (ver `openapi.yaml`): `+` opcional seguido de 7 a 15
+/// digitos.
+fn is_valid_phone(phone: &str) -> bool {
+    let digits = phone.strip_prefix('+').unwrap_or(phone);
+    (7..=15).contains(&digits.len()) && digits.chars().all(|c| c.is_ascii_digit())
+}
 
 /// Fallos posibles de `POST /api/v1/auth/refresh`.
 #[derive(Debug, Clone, PartialEq)]
@@ -180,6 +239,70 @@ impl ApiClient {
         }
     }
 
+    /// `POST /api/v1/auth/register/passenger`.
+    ///
+    /// El rol no se manda: lo fija el endpoint. Si la respuesta es exitosa,
+    /// la cuenta queda con sesion iniciada igual que tras un login (mismo
+    /// shape `AuthenticatedUser`).
+    pub async fn register_passenger(
+        &self,
+        name: &str,
+        email: &str,
+        phone: &str,
+        password: &str,
+    ) -> Result<AuthenticatedUser, RegisterError> {
+        let name = name.trim();
+        let email = email.trim();
+        let phone = phone.trim();
+
+        if name.is_empty() || email.is_empty() || phone.is_empty() || password.is_empty() {
+            return Err(RegisterError::EmptyFields);
+        }
+        if !is_valid_email(email) {
+            return Err(RegisterError::InvalidEmail);
+        }
+        if !is_valid_phone(phone) {
+            return Err(RegisterError::InvalidPhone);
+        }
+
+        let url = format!("{}/api/v1/auth/register/passenger", self.base_url);
+        let payload = RegisterPassengerPayload {
+            name: name.to_string(),
+            email: email.to_string(),
+            phone: phone.to_string(),
+            password: password.to_string(),
+        };
+
+        let response = self
+            .http
+            .post(url)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|err| RegisterError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<AuthenticatedUser> = response
+                .json()
+                .await
+                .map_err(|err| RegisterError::Network(err.to_string()))?;
+            return Ok(envelope.data);
+        }
+
+        match status.as_u16() {
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| RegisterError::Network(err.to_string()))?;
+                Err(RegisterError::Validation(body))
+            }
+            other => Err(RegisterError::Unexpected(other)),
+        }
+    }
+
     /// `POST /api/v1/auth/refresh`.
     ///
     /// Acepta el access token vigente aunque ya haya expirado, siempre que
@@ -293,6 +416,7 @@ impl ApiClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use wiremock::matchers::{body_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -392,6 +516,172 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, LoginError::Network(_)));
+    }
+
+    #[tokio::test]
+    async fn register_passenger_rejects_empty_fields_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .register_passenger("", "ana@example.com", "+573001234567", "motoya2026")
+                .await,
+            Err(RegisterError::EmptyFields)
+        );
+        assert_eq!(
+            client
+                .register_passenger("Ana Garcia", "", "+573001234567", "motoya2026")
+                .await,
+            Err(RegisterError::EmptyFields)
+        );
+        assert_eq!(
+            client
+                .register_passenger("Ana Garcia", "ana@example.com", "", "motoya2026")
+                .await,
+            Err(RegisterError::EmptyFields)
+        );
+        assert_eq!(
+            client
+                .register_passenger("Ana Garcia", "ana@example.com", "+573001234567", "")
+                .await,
+            Err(RegisterError::EmptyFields)
+        );
+    }
+
+    #[tokio::test]
+    async fn register_passenger_rejects_invalid_email_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .register_passenger("Ana Garcia", "not-an-email", "+573001234567", "motoya2026")
+                .await,
+            Err(RegisterError::InvalidEmail)
+        );
+    }
+
+    #[tokio::test]
+    async fn register_passenger_rejects_invalid_phone_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .register_passenger("Ana Garcia", "ana@example.com", "123", "motoya2026")
+                .await,
+            Err(RegisterError::InvalidPhone)
+        );
+        assert_eq!(
+            client
+                .register_passenger(
+                    "Ana Garcia",
+                    "ana@example.com",
+                    "+57-300-123-4567",
+                    "motoya2026"
+                )
+                .await,
+            Err(RegisterError::InvalidPhone)
+        );
+    }
+
+    #[tokio::test]
+    async fn register_passenger_returns_authenticated_user_on_success() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/register/passenger"))
+            .and(body_json(serde_json::json!({
+                "name": "Ana Garcia",
+                "email": "ana@example.com",
+                "phone": "+573001234567",
+                "password": "motoya2026",
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "data": {
+                    "user": {
+                        "id": 1,
+                        "name": "Ana Garcia",
+                        "email": "ana@example.com",
+                        "phone": "+573001234567",
+                        "role": "passenger",
+                    },
+                    "token": {
+                        "access_token": "jwt-token",
+                        "token_type": "bearer",
+                        "expires_in": 900,
+                    },
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let authenticated = client
+            .register_passenger(
+                "Ana Garcia",
+                "ana@example.com",
+                "+573001234567",
+                "motoya2026",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(authenticated.user.email, "ana@example.com");
+        assert_eq!(authenticated.token.access_token, "jwt-token");
+    }
+
+    #[tokio::test]
+    async fn register_passenger_returns_validation_error_on_422() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/register/passenger"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "The email has already been taken.",
+                "errors": {
+                    "email": ["The email has already been taken."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .register_passenger(
+                "Ana Garcia",
+                "ana@example.com",
+                "+573001234567",
+                "motoya2026",
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            RegisterError::Validation(ApiErrorBody {
+                message: "The email has already been taken.".to_string(),
+                errors: Some(HashMap::from([(
+                    "email".to_string(),
+                    vec!["The email has already been taken.".to_string()]
+                )])),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn register_passenger_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .register_passenger(
+                "Ana Garcia",
+                "ana@example.com",
+                "+573001234567",
+                "motoya2026",
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RegisterError::Network(_)));
     }
 
     fn sample_token() -> AuthToken {

--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -91,6 +91,24 @@ impl std::fmt::Display for RegisterError {
 
 impl std::error::Error for RegisterError {}
 
+impl RegisterError {
+    /// Mensaje de validacion especifico para `field` (p. ej. `"email"`), tal
+    /// como lo devuelve el backend campo por campo en `ApiErrorBody.errors`
+    /// de un 422 (ver `openapi.yaml`). `None` si el error no es de
+    /// validacion o el backend no reporto ese campo.
+    pub fn field_message(&self, field: &str) -> Option<String> {
+        match self {
+            RegisterError::Validation(body) => body
+                .errors
+                .as_ref()
+                .and_then(|errors| errors.get(field))
+                .and_then(|messages| messages.first())
+                .cloned(),
+            _ => None,
+        }
+    }
+}
+
 /// Formato basico (no unicidad, eso lo valida el backend): una arroba, con
 /// algo antes y un dominio con un punto despues.
 fn is_valid_email(email: &str) -> bool {
@@ -664,6 +682,20 @@ mod tests {
                     vec!["The email has already been taken.".to_string()]
                 )])),
             })
+        );
+        assert_eq!(
+            error.field_message("email"),
+            Some("The email has already been taken.".to_string())
+        );
+        assert_eq!(error.field_message("phone"), None);
+    }
+
+    #[test]
+    fn field_message_is_none_for_non_validation_errors() {
+        assert_eq!(RegisterError::EmptyFields.field_message("email"), None);
+        assert_eq!(
+            RegisterError::Network("boom".to_string()).field_message("email"),
+            None
         );
     }
 

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -65,6 +65,16 @@ pub struct LoginPayload {
     pub password: String,
 }
 
+/// Body de `POST /api/v1/auth/register/passenger`
+/// (`openapi.yaml#/components/schemas/PassengerRegistrationRequest`).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RegisterPassengerPayload {
+    pub name: String,
+    pub email: String,
+    pub phone: String,
+    pub password: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -9,6 +9,14 @@ pub mod screens;
 
 pub use map::{MapMarker, MapView};
 pub use screens::login::LoginScreen;
+pub use screens::register_passenger::RegisterPassengerScreen;
+
+/// Pantallas del flujo de autenticacion, previas a tener sesion iniciada.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum AuthScreen {
+    Login,
+    RegisterPassenger,
+}
 
 /// Raiz de la UI, agnostica de plataforma.
 ///
@@ -21,6 +29,7 @@ pub use screens::login::LoginScreen;
 pub fn App() -> Element {
     let storage = use_context::<Arc<dyn TokenStorage>>();
     let mut session = use_context_provider(SessionState::new);
+    let mut auth_screen = use_signal(|| AuthScreen::Login);
 
     // Restaura la sesion persistida (si hay una) al arrancar la app —
     // issue #3. Corre una sola vez: el closure no lee ningun signal, solo
@@ -34,7 +43,18 @@ pub fn App() -> Element {
         if session.is_authenticated() {
             Home {}
         } else {
-            LoginScreen {}
+            match auth_screen() {
+                AuthScreen::Login => rsx! {
+                    LoginScreen {
+                        on_register_click: move |_| auth_screen.set(AuthScreen::RegisterPassenger),
+                    }
+                },
+                AuthScreen::RegisterPassenger => rsx! {
+                    RegisterPassengerScreen {
+                        on_login_click: move |_| auth_screen.set(AuthScreen::Login),
+                    }
+                },
+            }
         }
     }
 }

--- a/crates/moto_ui/src/screens/login.rs
+++ b/crates/moto_ui/src/screens/login.rs
@@ -11,8 +11,14 @@ use moto_core::api::ApiClient;
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
 
+#[derive(Props, Clone, PartialEq)]
+pub struct LoginScreenProps {
+    /// Se dispara cuando el usuario pide ir a crear una cuenta de pasajero.
+    pub on_register_click: EventHandler<()>,
+}
+
 #[component]
-pub fn LoginScreen() -> Element {
+pub fn LoginScreen(props: LoginScreenProps) -> Element {
     let api_client = use_context::<ApiClient>();
     let storage = use_context::<Arc<dyn TokenStorage>>();
     let mut session = use_context::<SessionState>();
@@ -79,6 +85,12 @@ pub fn LoginScreen() -> Element {
             }
             if let Some(message) = error_message() {
                 p { class: "login-error", role: "alert", "{message}" }
+            }
+            button {
+                r#type: "button",
+                class: "login-register-link",
+                onclick: move |_| props.on_register_click.call(()),
+                "Crear cuenta de pasajero"
             }
         }
     }

--- a/crates/moto_ui/src/screens/mod.rs
+++ b/crates/moto_ui/src/screens/mod.rs
@@ -1,1 +1,2 @@
 pub mod login;
+pub mod register_passenger;

--- a/crates/moto_ui/src/screens/register_passenger.rs
+++ b/crates/moto_ui/src/screens/register_passenger.rs
@@ -1,0 +1,122 @@
+//! Pantalla de registro de pasajero — issue #6.
+//!
+//! Al registrarse exitosamente la sesion queda autenticada igual que tras un
+//! login (mismo shape `AuthenticatedUser`), asi que no hace falta encadenar
+//! un login aparte.
+
+use std::sync::Arc;
+
+use dioxus::prelude::*;
+use moto_core::api::ApiClient;
+use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
+
+#[derive(Props, Clone, PartialEq)]
+pub struct RegisterPassengerScreenProps {
+    /// Se dispara cuando el usuario pide volver a la pantalla de login.
+    pub on_login_click: EventHandler<()>,
+}
+
+#[component]
+pub fn RegisterPassengerScreen(props: RegisterPassengerScreenProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut name = use_signal(String::new);
+    let mut email = use_signal(String::new);
+    let mut phone = use_signal(String::new);
+    let mut password = use_signal(String::new);
+    let mut error_message = use_signal(|| None::<String>);
+    let mut is_loading = use_signal(|| false);
+
+    let on_submit = move |event: FormEvent| {
+        event.prevent_default();
+
+        let name_value = name();
+        let email_value = email();
+        let phone_value = phone();
+        let password_value = password();
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            error_message.set(None);
+
+            match api_client
+                .register_passenger(&name_value, &email_value, &phone_value, &password_value)
+                .await
+            {
+                Ok(authenticated) => {
+                    session.authenticate(authenticated, storage.as_ref());
+                }
+                Err(err) => {
+                    error_message.set(Some(err.to_string()));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    };
+
+    rsx! {
+        div { class: "register-passenger-screen",
+            h1 { "Crear cuenta de pasajero" }
+            form { onsubmit: on_submit,
+                label { r#for: "register-passenger-name", "Nombre" }
+                input {
+                    id: "register-passenger-name",
+                    r#type: "text",
+                    autocomplete: "name",
+                    disabled: is_loading(),
+                    value: "{name}",
+                    oninput: move |event| name.set(event.value()),
+                }
+                label { r#for: "register-passenger-email", "Email" }
+                input {
+                    id: "register-passenger-email",
+                    r#type: "email",
+                    autocomplete: "username",
+                    disabled: is_loading(),
+                    value: "{email}",
+                    oninput: move |event| email.set(event.value()),
+                }
+                label { r#for: "register-passenger-phone", "Telefono" }
+                input {
+                    id: "register-passenger-phone",
+                    r#type: "tel",
+                    autocomplete: "tel",
+                    disabled: is_loading(),
+                    value: "{phone}",
+                    oninput: move |event| phone.set(event.value()),
+                }
+                label { r#for: "register-passenger-password", "Contrasena" }
+                input {
+                    id: "register-passenger-password",
+                    r#type: "password",
+                    autocomplete: "new-password",
+                    disabled: is_loading(),
+                    value: "{password}",
+                    oninput: move |event| password.set(event.value()),
+                }
+                button { r#type: "submit", disabled: is_loading(),
+                    if is_loading() {
+                        "Creando cuenta..."
+                    } else {
+                        "Crear cuenta"
+                    }
+                }
+            }
+            if let Some(message) = error_message() {
+                p { class: "register-passenger-error", role: "alert", "{message}" }
+            }
+            button {
+                r#type: "button",
+                class: "register-passenger-login-link",
+                onclick: move |_| props.on_login_click.call(()),
+                "Ya tengo cuenta, iniciar sesion"
+            }
+        }
+    }
+}

--- a/crates/moto_ui/src/screens/register_passenger.rs
+++ b/crates/moto_ui/src/screens/register_passenger.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use dioxus::prelude::*;
-use moto_core::api::ApiClient;
+use moto_core::api::{ApiClient, RegisterError};
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
 
@@ -27,7 +27,7 @@ pub fn RegisterPassengerScreen(props: RegisterPassengerScreenProps) -> Element {
     let mut email = use_signal(String::new);
     let mut phone = use_signal(String::new);
     let mut password = use_signal(String::new);
-    let mut error_message = use_signal(|| None::<String>);
+    let mut register_error = use_signal(|| None::<RegisterError>);
     let mut is_loading = use_signal(|| false);
 
     let on_submit = move |event: FormEvent| {
@@ -42,7 +42,7 @@ pub fn RegisterPassengerScreen(props: RegisterPassengerScreenProps) -> Element {
 
         spawn(async move {
             is_loading.set(true);
-            error_message.set(None);
+            register_error.set(None);
 
             match api_client
                 .register_passenger(&name_value, &email_value, &phone_value, &password_value)
@@ -52,12 +52,38 @@ pub fn RegisterPassengerScreen(props: RegisterPassengerScreenProps) -> Element {
                     session.authenticate(authenticated, storage.as_ref());
                 }
                 Err(err) => {
-                    error_message.set(Some(err.to_string()));
+                    register_error.set(Some(err));
                 }
             }
 
             is_loading.set(false);
         });
+    };
+
+    let current_error = register_error();
+    let name_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("name"));
+    let email_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("email"));
+    let phone_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("phone"));
+    let password_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("password"));
+    // El mensaje generico solo se muestra cuando el error no trae desglose
+    // campo por campo (p. ej. red, 5xx, o EmptyFields) para no repetir el
+    // mismo texto dos veces cuando ya se pinta junto al input afectado.
+    let has_field_errors = name_error.is_some()
+        || email_error.is_some()
+        || phone_error.is_some()
+        || password_error.is_some();
+    let general_message = if has_field_errors {
+        None
+    } else {
+        current_error.as_ref().map(|err| err.to_string())
     };
 
     rsx! {
@@ -73,6 +99,9 @@ pub fn RegisterPassengerScreen(props: RegisterPassengerScreenProps) -> Element {
                     value: "{name}",
                     oninput: move |event| name.set(event.value()),
                 }
+                if let Some(message) = &name_error {
+                    p { class: "register-passenger-field-error", role: "alert", "{message}" }
+                }
                 label { r#for: "register-passenger-email", "Email" }
                 input {
                     id: "register-passenger-email",
@@ -81,6 +110,9 @@ pub fn RegisterPassengerScreen(props: RegisterPassengerScreenProps) -> Element {
                     disabled: is_loading(),
                     value: "{email}",
                     oninput: move |event| email.set(event.value()),
+                }
+                if let Some(message) = &email_error {
+                    p { class: "register-passenger-field-error", role: "alert", "{message}" }
                 }
                 label { r#for: "register-passenger-phone", "Telefono" }
                 input {
@@ -91,6 +123,9 @@ pub fn RegisterPassengerScreen(props: RegisterPassengerScreenProps) -> Element {
                     value: "{phone}",
                     oninput: move |event| phone.set(event.value()),
                 }
+                if let Some(message) = &phone_error {
+                    p { class: "register-passenger-field-error", role: "alert", "{message}" }
+                }
                 label { r#for: "register-passenger-password", "Contrasena" }
                 input {
                     id: "register-passenger-password",
@@ -100,6 +135,9 @@ pub fn RegisterPassengerScreen(props: RegisterPassengerScreenProps) -> Element {
                     value: "{password}",
                     oninput: move |event| password.set(event.value()),
                 }
+                if let Some(message) = &password_error {
+                    p { class: "register-passenger-field-error", role: "alert", "{message}" }
+                }
                 button { r#type: "submit", disabled: is_loading(),
                     if is_loading() {
                         "Creando cuenta..."
@@ -108,7 +146,7 @@ pub fn RegisterPassengerScreen(props: RegisterPassengerScreenProps) -> Element {
                     }
                 }
             }
-            if let Some(message) = error_message() {
+            if let Some(message) = general_message {
                 p { class: "register-passenger-error", role: "alert", "{message}" }
             }
             button {


### PR DESCRIPTION
Closes #6

## Qué hace

- `ApiClient::register_passenger` en `moto_core::api`: `POST /api/v1/auth/register/passenger`. Valida en el cliente (campos vacíos, formato básico de email y teléfono E.164) antes de llamar a la API — la unicidad y la política de contraseña las sigue validando el backend (`RegisterError::Validation` en un 422).
- `RegisterPassengerPayload` en `moto_core::models`, reflejando `PassengerRegistrationRequest` de `openapi.yaml`.
- `RegisterPassengerScreen` en `moto_ui::screens`, misma estructura que `LoginScreen`: estado de carga/error explícito, y al registrarse exitosamente autentica la sesión igual que el login (mismo `AuthenticatedUser`).
- Navegación mínima login↔registro (`AuthScreen` en `App`, prop `on_register_click`/`on_login_click`) para que la pantalla nueva sea alcanzable — sin esto quedaba código muerto.

## Cómo se probó

- `cargo fmt --all -- --check`, `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`, `cargo test --workspace` (34 tests, todos en verde) y `cargo build --package web --target wasm32-unknown-unknown`, todos en verde localmente.
- Tests nuevos en `moto_core::api::tests` cubren: campos vacíos (por campo), email/teléfono con formato inválido (sin llegar a mandar la request), éxito (201 → `AuthenticatedUser`), error de validación del backend (422), y error de red.

## Decisiones y riesgos

- El endpoint de registro de conductor (`/auth/register/driver`, issue #7) queda fuera de alcance de este PR.
- El entorno de esta máquina tuvo antes un bloqueo real de `rustc` (crash en cualquier codegen, ver issue #5) que ya no se reproduce. El build de `web` sí mostró un panic interno de `rustc` puntual bajo compilación en paralelo (`alloc::str` fuera de rango) que no se repitió en una segunda corrida ni corriendo con `-j 1`; no está relacionado con el código de este cambio (verificado con `cargo test`/`clippy` en verde antes y después).