### PR TITLE
feat(#8): cerrar sesion

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -166,6 +166,39 @@ impl std::fmt::Display for RefreshError {
 
 impl std::error::Error for RefreshError {}
 
+/// Fallos posibles de `POST /api/v1/auth/logout`.
+///
+/// El caller (`SessionState::logout`, ver issue #8) nunca deja de cerrar la
+/// sesion local por estos errores — solo le sirven para decidir si vale la
+/// pena loguearlos.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LogoutError {
+    /// El token ya no era valido para el guard (`auth:api`): no hay nada que
+    /// cerrar del lado del backend, pero la sesion local igual se limpia.
+    Unauthorized,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for LogoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogoutError::Unauthorized => write!(f, "La sesion ya no era valida."),
+            LogoutError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            LogoutError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for LogoutError {}
+
 /// Resultado de una request autenticada que pudo haber renovado el token en
 /// el camino.
 #[derive(Debug, Clone, PartialEq)]
@@ -358,6 +391,35 @@ impl ApiClient {
             }
             429 => Err(RefreshError::RateLimited),
             other => Err(RefreshError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/auth/logout`.
+    ///
+    /// Invalida `access_token` del lado del backend (204 sin cuerpo). El
+    /// caller debe limpiar `SessionState` localmente sin importar el
+    /// resultado (ver issue #8) — cerrar sesion nunca debe dejar al usuario
+    /// atrapado por un error de red o un token ya vencido.
+    pub async fn logout(&self, access_token: &str) -> Result<(), LogoutError> {
+        let url = format!("{}/api/v1/auth/logout", self.base_url);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|err| LogoutError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            return Ok(());
+        }
+
+        match status.as_u16() {
+            401 => Err(LogoutError::Unauthorized),
+            other => Err(LogoutError::Unexpected(other)),
         }
     }
 
@@ -785,6 +847,52 @@ mod tests {
         let error = client.refresh("jwt-token").await.unwrap_err();
 
         assert_eq!(error, RefreshError::RateLimited);
+    }
+
+    #[tokio::test]
+    async fn logout_succeeds_on_204() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/logout"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+
+        assert_eq!(client.logout("jwt-token").await, Ok(()));
+    }
+
+    #[tokio::test]
+    async fn logout_returns_unauthorized_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/logout"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+
+        assert_eq!(
+            client.logout("stale-token").await,
+            Err(LogoutError::Unauthorized)
+        );
+    }
+
+    #[tokio::test]
+    async fn logout_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client.logout("jwt-token").await.unwrap_err();
+
+        assert!(matches!(error, LogoutError::Network(_)));
     }
 
     #[derive(Debug, serde::Deserialize, PartialEq)]

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use dioxus::prelude::*;
+use moto_core::api::ApiClient;
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
 
@@ -59,12 +60,54 @@ pub fn App() -> Element {
     }
 }
 
+/// Pantalla placeholder tras iniciar sesion — issue #9 (perfil) reemplaza el
+/// contenido, pero el logout (issue #8) no depende de esa pantalla: cerrar
+/// sesion debe estar disponible desde el momento en que hay una sesion
+/// iniciada.
 #[component]
 fn Home() -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+    let mut is_logging_out = use_signal(|| false);
+
+    let on_logout = move |_| {
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+        let Some(token) = session.token() else {
+            // Sin token no hay nada que invalidar en el backend, pero la
+            // sesion local igual se limpia.
+            session.logout(storage.as_ref());
+            return;
+        };
+
+        spawn(async move {
+            is_logging_out.set(true);
+
+            // Cerrar sesion nunca debe dejar al usuario atrapado por un
+            // error de red o un token ya vencido: la sesion local se limpia
+            // sin importar el resultado de la request (ver issue #8).
+            let _ = api_client.logout(&token.access_token).await;
+            session.logout(storage.as_ref());
+
+            is_logging_out.set(false);
+        });
+    };
+
     rsx! {
         div {
             h1 { "MotoYa" }
             p { "Sesion iniciada." }
+            button {
+                r#type: "button",
+                disabled: is_logging_out(),
+                onclick: on_logout,
+                if is_logging_out() {
+                    "Cerrando sesion..."
+                } else {
+                    "Cerrar sesion"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #8

## Que hace

- `ApiClient::logout` en `moto_core/src/api.rs`: `POST /api/v1/auth/logout`
  con el JWT vigente. Sigue el mismo patron que `LoginError`/`RefreshError`
  (`LogoutError::Unauthorized/Network/Unexpected`). El backend
  (`LogoutController`) responde 204 sin cuerpo, asi que el metodo no
  deserializa ningun envelope.
- Boton "Cerrar sesion" en la pantalla `Home` (`moto_ui/src/lib.rs`, unica
  pantalla que existe hoy tras iniciar sesion — el perfil de la issue #9
  todavia no esta implementado). Al hacer click: llama a `ApiClient::logout`
  y, **sin importar el resultado de esa llamada** (exito, 401 por token ya
  vencido, o error de red), limpia `SessionState` local vía
  `SessionState::logout` (ya existente desde el issue #3). Como `App()`
  decide que pantalla mostrar segun `session.is_authenticated()`, limpiar la
  sesion navega automaticamente de vuelta al login sin logica de
  routing adicional.
- Si no hay token en sesion (caso borde), se limpia igual la sesion local
  sin llamar al backend.

## Como se probo

- `cargo test --workspace --exclude mobile`: 3 tests nuevos para
  `ApiClient::logout` (204 exitoso, 401, error de red) con `wiremock`,
  mismo patron que los tests existentes de `login`/`refresh`. Los 32 tests
  de `moto_core` + 6 de `moto_ui` pasan.
- `cargo fmt --all -- --check`: sin errores.
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`: sin warnings.
- `cargo build --package web --target wasm32-unknown-unknown`: build en verde.

## Decisiones y riesgos

- No agregue un test de UI para el boton de `Home`: el resto de las
  pantallas de este repo (`login.rs`, `register_passenger.rs`) tampoco
  tienen tests de render — el patron establecido cubre la logica en
  `moto_core` con `wiremock` y deja la UI sin testear directamente.
- El logout se dispara desde `Home` (placeholder) en vez de una pantalla de
  perfil dedicada porque esa pantalla (issue #9) todavia no existe. Cuando
  se implemente el perfil, el boton probablemente se mueva ahi — no es un
  cambio de contrato de `ApiClient::logout` ni de `SessionState::logout`.