### PR TITLE
feat(#9): ver mi perfil

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -6,7 +6,7 @@
 
 use crate::models::{
     ApiErrorBody, AuthToken, AuthenticatedUser, DataEnvelope, LoginPayload,
-    RegisterPassengerPayload,
+    RegisterPassengerPayload, User,
 };
 
 #[derive(Debug, Clone)]
@@ -220,6 +220,27 @@ pub enum AuthenticatedRequestError {
     Network(String),
     Unexpected(u16),
 }
+
+impl std::fmt::Display for AuthenticatedRequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthenticatedRequestError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            AuthenticatedRequestError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            AuthenticatedRequestError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AuthenticatedRequestError {}
 
 enum GetOutcome<T> {
     Success(T),
@@ -490,6 +511,15 @@ impl ApiClient {
         }
 
         Err(AuthenticatedRequestError::Unexpected(status.as_u16()))
+    }
+
+    /// `GET /api/v1/me` — issue #9. Reintenta una vez con refresh de token
+    /// (ver `get_authenticated`) antes de forzar `SessionExpired`.
+    pub async fn me(
+        &self,
+        token: &AuthToken,
+    ) -> Result<AuthenticatedFetch<User>, AuthenticatedRequestError> {
+        self.get_authenticated::<User>("/api/v1/me", token).await
     }
 }
 
@@ -1007,6 +1037,62 @@ mod tests {
             .get_authenticated::<Probe>("/api/v1/_probe", &sample_token())
             .await
             .unwrap_err();
+
+        assert_eq!(error, AuthenticatedRequestError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn me_returns_the_authenticated_account() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "id": 1,
+                    "name": "Ana Garcia",
+                    "email": "ana@example.com",
+                    "phone": "+573001234567",
+                    "role": "passenger",
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.me(&sample_token()).await.unwrap();
+
+        assert_eq!(fetch.data.name, "Ana Garcia");
+        assert_eq!(fetch.data.role, crate::models::Role::Passenger);
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn me_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.me(&sample_token()).await.unwrap_err();
 
         assert_eq!(error, AuthenticatedRequestError::SessionExpired);
     }

--- a/crates/moto_core/src/state.rs
+++ b/crates/moto_core/src/state.rs
@@ -73,6 +73,13 @@ impl SessionState {
         storage.save(&token);
         self.token.set(Some(token));
     }
+
+    /// Guarda los datos de cuenta que devolvio `GET /api/v1/me` (issue #9).
+    /// No toca el token: el caller que haya recibido un `refreshed_token`
+    /// junto a la respuesta debe persistirlo aparte con `update_token`.
+    pub fn set_user(&mut self, user: User) {
+        self.user.set(Some(user));
+    }
 }
 
 impl Default for SessionState {
@@ -239,5 +246,25 @@ mod tests {
         assert_eq!(session_access_token.as_deref(), Some("renewed-token"));
         assert_eq!(saved_access_token.as_deref(), Some("renewed-token"));
         assert!(has_user);
+    }
+
+    #[test]
+    fn set_user_populates_the_profile_without_touching_the_token() {
+        let (user, token) = run_in_runtime(|| {
+            let storage = InMemoryTokenStorage::new();
+            let mut session = SessionState::new();
+            session.authenticate(sample_authenticated(), &storage);
+
+            let updated = User {
+                name: "Ana Garcia Actualizada".to_string(),
+                ..sample_authenticated().user
+            };
+            session.set_user(updated.clone());
+
+            (session.user(), session.token())
+        });
+
+        assert_eq!(user.unwrap().name, "Ana Garcia Actualizada");
+        assert_eq!(token.unwrap().access_token, "jwt-token");
     }
 }

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -10,6 +10,7 @@ pub mod screens;
 
 pub use map::{MapMarker, MapView};
 pub use screens::login::LoginScreen;
+pub use screens::profile::ProfileScreen;
 pub use screens::register_passenger::RegisterPassengerScreen;
 
 /// Pantallas del flujo de autenticacion, previas a tener sesion iniciada.
@@ -60,10 +61,9 @@ pub fn App() -> Element {
     }
 }
 
-/// Pantalla placeholder tras iniciar sesion — issue #9 (perfil) reemplaza el
-/// contenido, pero el logout (issue #8) no depende de esa pantalla: cerrar
-/// sesion debe estar disponible desde el momento en que hay una sesion
-/// iniciada.
+/// Pantalla principal tras iniciar sesion: perfil (issue #9) mas el logout
+/// (issue #8), que no depende de la pantalla de perfil — cerrar sesion debe
+/// estar disponible desde el momento en que hay una sesion iniciada.
 #[component]
 fn Home() -> Element {
     let api_client = use_context::<ApiClient>();
@@ -97,7 +97,7 @@ fn Home() -> Element {
     rsx! {
         div {
             h1 { "MotoYa" }
-            p { "Sesion iniciada." }
+            ProfileScreen {}
             button {
                 r#type: "button",
                 disabled: is_logging_out(),

--- a/crates/moto_ui/src/screens/mod.rs
+++ b/crates/moto_ui/src/screens/mod.rs
@@ -1,2 +1,3 @@
 pub mod login;
+pub mod profile;
 pub mod register_passenger;

--- a/crates/moto_ui/src/screens/profile.rs
+++ b/crates/moto_ui/src/screens/profile.rs
@@ -1,0 +1,96 @@
+//! Pantalla de perfil (pasajero y conductor) — issue #9.
+//!
+//! Consume `GET /api/v1/me` a traves de `ApiClient::me`, que ya trae el
+//! reintento con refresh de token (issue #3). Si el refresh tambien falla,
+//! la sesion se cierra en vez de mostrar un error suelto en pantalla — es
+//! justo el criterio de aceptacion del issue.
+
+use std::sync::Arc;
+
+use dioxus::prelude::*;
+use moto_core::api::{ApiClient, AuthenticatedRequestError};
+use moto_core::models::Role;
+use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
+
+fn role_label(role: Role) -> &'static str {
+    match role {
+        Role::Passenger => "Pasajero",
+        Role::Driver => "Conductor",
+    }
+}
+
+#[component]
+pub fn ProfileScreen() -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut is_loading = use_signal(|| false);
+    let mut error_message = use_signal(|| None::<String>);
+    // Guarda contra volver a disparar el fetch: el efecto lee `session.token()`
+    // en su primera corrida (para mandarlo en la request), lo que lo suscribe
+    // a ese signal. Sin esta bandera, el `update_token`/`logout` que dispara
+    // el propio fetch reprogramaria el efecto en un loop. Una vez que
+    // `has_fetched` es `true`, las corridas siguientes retornan antes de leer
+    // `session.token()` de nuevo, asi que dejan de depender de el.
+    let mut has_fetched = use_signal(|| false);
+
+    use_effect(move || {
+        if has_fetched() {
+            return;
+        }
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        has_fetched.set(true);
+
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            error_message.set(None);
+
+            match api_client.me(&token).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    session.set_user(fetch.data);
+                }
+                Err(AuthenticatedRequestError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    error_message.set(Some(err.to_string()));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    });
+
+    rsx! {
+        div { class: "profile-screen",
+            h2 { "Mi perfil" }
+            if is_loading() {
+                p { "Cargando perfil..." }
+            } else if let Some(message) = error_message() {
+                p { class: "profile-error", role: "alert", "{message}" }
+            } else if let Some(user) = session.user() {
+                dl {
+                    dt { "Nombre" }
+                    dd { "{user.name}" }
+                    dt { "Email" }
+                    dd { "{user.email}" }
+                    dt { "Telefono" }
+                    dd { "{user.phone}" }
+                    dt { "Rol" }
+                    dd { "{role_label(user.role)}" }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #9

## Qué hace

Pantalla de perfil (`ProfileScreen`) que consume `GET /api/v1/me` al entrar a
`Home` tras iniciar sesión, y muestra nombre, email, teléfono y rol de la
cuenta autenticada.

- `ApiClient::me` (`moto_core::api`): wrapper delgado sobre
  `get_authenticated::<User>("/api/v1/me", token)`, que ya trae el reintento
  con refresh automático de token (issue #3).
- `SessionState::set_user` (`moto_core::state`): guarda el `User` devuelto sin
  tocar el token.
- `AuthenticatedRequestError` ahora implementa `Display`/`Error` (lo pedía
  `ProfileScreen` para mostrar el mensaje de error en pantalla; los demás
  errores de `api.rs` ya seguían este patrón).
- `ProfileScreen` (`moto_ui::screens::profile`): hace el fetch una sola vez al
  montar, con estados explícitos de carga/error. Si el refresh de token
  falla (`SessionExpired`), cierra la sesión local en vez de mostrar un error
  suelto — igual que ya hace el logout (issue #8) — así el usuario vuelve al
  login. Reemplaza el placeholder de `Home` en `moto_ui::lib`, sin tocar el
  botón de logout que ya vivía ahí.

## Cómo se probó

- `cargo test --workspace`: 41 tests en verde (agrego 4 nuevos — `me` con
  éxito y con `SessionExpired`, `set_user`).
- `cargo fmt --all -- --check` y
  `cargo clippy --all-targets --all-features -- -D warnings` en verde.
- `cargo build --package web --target wasm32-unknown-unknown` en verde.
- El renderizado real de `ProfileScreen` (navegador/emulador) no se cubre
  aquí: `moto_core` es lo testeable en CI (ver `.claude/STANDARDS.md`); la UI
  sigue el mismo patrón sin tests que `LoginScreen`/`RegisterPassengerScreen`.

## Decisiones y riesgos

- El fetch usa un flag `has_fetched` dentro de `use_effect` para evitar que
  Dioxus reprograme el efecto cuando el propio fetch actualiza el token
  (`update_token`) o cierra sesión (`logout`) — ambos mutan el signal que el
  efecto lee para mandar la request. Queda comentado en el código porque no
  es obvio a simple vista.
- No hay endpoint gap: `GET /api/v1/me` y el shape `User` ya existían en el
  contrato (mismo `User` que devuelve login/registro).