### PR TITLE
feat(#10): actualizar mi perfil

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -6,7 +6,7 @@
 
 use crate::models::{
     ApiErrorBody, AuthToken, AuthenticatedUser, DataEnvelope, LoginPayload,
-    RegisterPassengerPayload, User,
+    RegisterPassengerPayload, UpdateProfilePayload, User,
 };
 
 #[derive(Debug, Clone)]
@@ -242,9 +242,73 @@ impl std::fmt::Display for AuthenticatedRequestError {
 
 impl std::error::Error for AuthenticatedRequestError {}
 
+/// Fallos posibles de `PATCH /api/v1/me`.
+///
+/// `NoFields` se detecta en el cliente antes de mandar la request: un PATCH
+/// sin ningun campo no tiene nada que actualizar (ver issue #10).
+#[derive(Debug, Clone, PartialEq)]
+pub enum UpdateProfileError {
+    NoFields,
+    InvalidEmail,
+    InvalidPhone,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for UpdateProfileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UpdateProfileError::NoFields => write!(f, "No hay ningun cambio para guardar."),
+            UpdateProfileError::InvalidEmail => write!(f, "Ingresa un email valido."),
+            UpdateProfileError::InvalidPhone => {
+                write!(f, "Ingresa un telefono valido (7 a 15 digitos).")
+            }
+            UpdateProfileError::Validation(body) => write!(f, "{}", body.message),
+            UpdateProfileError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            UpdateProfileError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            UpdateProfileError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for UpdateProfileError {}
+
+impl UpdateProfileError {
+    /// Mensaje de validacion especifico para `field`, igual que
+    /// `RegisterError::field_message`.
+    pub fn field_message(&self, field: &str) -> Option<String> {
+        match self {
+            UpdateProfileError::Validation(body) => body
+                .errors
+                .as_ref()
+                .and_then(|errors| errors.get(field))
+                .and_then(|messages| messages.first())
+                .cloned(),
+            _ => None,
+        }
+    }
+}
+
 enum GetOutcome<T> {
     Success(T),
     Unauthorized,
+}
+
+enum PatchOutcome<T> {
+    Success(T),
+    Unauthorized,
+    Validation(ApiErrorBody),
 }
 
 impl ApiClient {
@@ -520,6 +584,105 @@ impl ApiClient {
         token: &AuthToken,
     ) -> Result<AuthenticatedFetch<User>, AuthenticatedRequestError> {
         self.get_authenticated::<User>("/api/v1/me", token).await
+    }
+
+    /// `PATCH /api/v1/me` — issue #10. PATCH parcial: solo los campos
+    /// presentes en `update` viajan en el body (ver `UpdateProfilePayload`).
+    /// Reintenta una vez con refresh de token ante un 401, igual que
+    /// `get_authenticated`; un 422 de validacion, en cambio, nunca se
+    /// reintenta.
+    pub async fn update_profile(
+        &self,
+        token: &AuthToken,
+        update: UpdateProfilePayload,
+    ) -> Result<AuthenticatedFetch<User>, UpdateProfileError> {
+        if update.name.is_none() && update.email.is_none() && update.phone.is_none() {
+            return Err(UpdateProfileError::NoFields);
+        }
+        if let Some(email) = &update.email
+            && !is_valid_email(email)
+        {
+            return Err(UpdateProfileError::InvalidEmail);
+        }
+        if let Some(phone) = &update.phone
+            && !is_valid_phone(phone)
+        {
+            return Err(UpdateProfileError::InvalidPhone);
+        }
+
+        match self
+            .patch_with_token::<User>("/api/v1/me", &token.access_token, &update)
+            .await?
+        {
+            PatchOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            PatchOutcome::Validation(body) => return Err(UpdateProfileError::Validation(body)),
+            PatchOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| UpdateProfileError::SessionExpired)?;
+
+        match self
+            .patch_with_token::<User>("/api/v1/me", &renewed.access_token, &update)
+            .await?
+        {
+            PatchOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            PatchOutcome::Validation(body) => Err(UpdateProfileError::Validation(body)),
+            PatchOutcome::Unauthorized => Err(UpdateProfileError::SessionExpired),
+        }
+    }
+
+    async fn patch_with_token<T>(
+        &self,
+        path: &str,
+        access_token: &str,
+        body: &UpdateProfilePayload,
+    ) -> Result<PatchOutcome<T>, UpdateProfileError>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let url = format!("{}{}", self.base_url, path);
+
+        let response = self
+            .http
+            .patch(url)
+            .bearer_auth(access_token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|err| UpdateProfileError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<T> = response
+                .json()
+                .await
+                .map_err(|err| UpdateProfileError::Network(err.to_string()))?;
+            return Ok(PatchOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(PatchOutcome::Unauthorized),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| UpdateProfileError::Network(err.to_string()))?;
+                Ok(PatchOutcome::Validation(body))
+            }
+            other => Err(UpdateProfileError::Unexpected(other)),
+        }
     }
 }
 
@@ -1095,5 +1258,259 @@ mod tests {
         let error = client.me(&sample_token()).await.unwrap_err();
 
         assert_eq!(error, AuthenticatedRequestError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn update_profile_rejects_an_empty_patch_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        let error = client
+            .update_profile(&sample_token(), UpdateProfilePayload::default())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, UpdateProfileError::NoFields);
+    }
+
+    #[tokio::test]
+    async fn update_profile_rejects_invalid_email_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        let error = client
+            .update_profile(
+                &sample_token(),
+                UpdateProfilePayload {
+                    email: Some("not-an-email".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, UpdateProfileError::InvalidEmail);
+    }
+
+    #[tokio::test]
+    async fn update_profile_rejects_invalid_phone_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        let error = client
+            .update_profile(
+                &sample_token(),
+                UpdateProfilePayload {
+                    phone: Some("123".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, UpdateProfileError::InvalidPhone);
+    }
+
+    #[tokio::test]
+    async fn update_profile_sends_only_the_present_fields_and_returns_the_updated_account() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/me"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .and(body_json(serde_json::json!({
+                "name": "Ana Garcia Perez",
+                "phone": "+573007654321",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "id": 1,
+                    "name": "Ana Garcia Perez",
+                    "email": "ana@example.com",
+                    "phone": "+573007654321",
+                    "role": "passenger",
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .update_profile(
+                &sample_token(),
+                UpdateProfilePayload {
+                    name: Some("Ana Garcia Perez".to_string()),
+                    email: None,
+                    phone: Some("+573007654321".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.name, "Ana Garcia Perez");
+        assert_eq!(fetch.data.phone, "+573007654321");
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn update_profile_returns_validation_error_on_422_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/me"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "The email has already been taken.",
+                "errors": {
+                    "email": ["The email has already been taken."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .update_profile(
+                &sample_token(),
+                UpdateProfilePayload {
+                    email: Some("ana@example.com".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            UpdateProfileError::Validation(ApiErrorBody {
+                message: "The email has already been taken.".to_string(),
+                errors: Some(HashMap::from([(
+                    "email".to_string(),
+                    vec!["The email has already been taken.".to_string()]
+                )])),
+            })
+        );
+        assert_eq!(
+            error.field_message("email"),
+            Some("The email has already been taken.".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn update_profile_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/me"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/me"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "id": 1,
+                    "name": "Ana Garcia Perez",
+                    "email": "ana@example.com",
+                    "phone": "+573001234567",
+                    "role": "passenger",
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .update_profile(
+                &sample_token(),
+                UpdateProfilePayload {
+                    name: Some("Ana Garcia Perez".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.name, "Ana Garcia Perez");
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn update_profile_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/me"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .update_profile(
+                &sample_token(),
+                UpdateProfilePayload {
+                    name: Some("Ana Garcia Perez".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, UpdateProfileError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn update_profile_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .update_profile(
+                &sample_token(),
+                UpdateProfilePayload {
+                    name: Some("Ana Garcia Perez".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, UpdateProfileError::Network(_)));
     }
 }

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -75,6 +75,22 @@ pub struct RegisterPassengerPayload {
     pub password: String,
 }
 
+/// Body de `PATCH /api/v1/me`
+/// (`openapi.yaml#/components/schemas/UpdateProfileRequest`).
+///
+/// PATCH parcial: cada campo ausente (`None`) se omite del JSON en vez de
+/// viajar como `null`, para que el backend conserve el valor actual en vez
+/// de interpretarlo como "borrar este dato" (ver issue #10).
+#[derive(Debug, Clone, Serialize, PartialEq, Default)]
+pub struct UpdateProfilePayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,6 +122,25 @@ mod tests {
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
         );
         assert_eq!(envelope.data.token.expires_in, Some(900));
+    }
+
+    #[test]
+    fn update_profile_payload_omits_absent_fields_from_the_json() {
+        let payload = UpdateProfilePayload {
+            name: Some("Ana Garcia Perez".to_string()),
+            email: None,
+            phone: Some("+573007654321".to_string()),
+        };
+
+        let json = serde_json::to_value(&payload).unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "name": "Ana Garcia Perez",
+                "phone": "+573007654321",
+            })
+        );
     }
 
     #[test]

--- a/crates/moto_ui/src/screens/profile.rs
+++ b/crates/moto_ui/src/screens/profile.rs
@@ -1,15 +1,20 @@
-//! Pantalla de perfil (pasajero y conductor) — issue #9.
+//! Pantalla de perfil (pasajero y conductor) — issue #9 — mas la edicion de
+//! datos de contacto — issue #10.
 //!
 //! Consume `GET /api/v1/me` a traves de `ApiClient::me`, que ya trae el
 //! reintento con refresh de token (issue #3). Si el refresh tambien falla,
 //! la sesion se cierra en vez de mostrar un error suelto en pantalla — es
 //! justo el criterio de aceptacion del issue.
+//!
+//! La edicion (issue #10) reusa esta misma pantalla en vez de ser una
+//! pantalla aparte: el formulario se precarga con `session.user()` y, al
+//! guardar, llama a `ApiClient::update_profile` (`PATCH /api/v1/me`).
 
 use std::sync::Arc;
 
 use dioxus::prelude::*;
-use moto_core::api::{ApiClient, AuthenticatedRequestError};
-use moto_core::models::Role;
+use moto_core::api::{ApiClient, AuthenticatedRequestError, UpdateProfileError};
+use moto_core::models::{Role, UpdateProfilePayload, User};
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
 
@@ -72,6 +77,8 @@ pub fn ProfileScreen() -> Element {
         });
     });
 
+    let mut is_editing = use_signal(|| false);
+
     rsx! {
         div { class: "profile-screen",
             h2 { "Mi perfil" }
@@ -80,17 +87,172 @@ pub fn ProfileScreen() -> Element {
             } else if let Some(message) = error_message() {
                 p { class: "profile-error", role: "alert", "{message}" }
             } else if let Some(user) = session.user() {
-                dl {
-                    dt { "Nombre" }
-                    dd { "{user.name}" }
-                    dt { "Email" }
-                    dd { "{user.email}" }
-                    dt { "Telefono" }
-                    dd { "{user.phone}" }
-                    dt { "Rol" }
-                    dd { "{role_label(user.role)}" }
+                if is_editing() {
+                    EditProfileForm {
+                        user,
+                        on_saved: move |()| is_editing.set(false),
+                        on_cancel: move |()| is_editing.set(false),
+                    }
+                } else {
+                    dl {
+                        dt { "Nombre" }
+                        dd { "{user.name}" }
+                        dt { "Email" }
+                        dd { "{user.email}" }
+                        dt { "Telefono" }
+                        dd { "{user.phone}" }
+                        dt { "Rol" }
+                        dd { "{role_label(user.role)}" }
+                    }
+                    button {
+                        r#type: "button",
+                        class: "profile-edit-button",
+                        onclick: move |_| is_editing.set(true),
+                        "Editar perfil"
+                    }
                 }
             }
+        }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct EditProfileFormProps {
+    user: User,
+    on_saved: EventHandler<()>,
+    on_cancel: EventHandler<()>,
+}
+
+/// Formulario de edicion de nombre/email/telefono — issue #10. Precargado
+/// con `props.user`; al guardar manda solo los campos presentes en el
+/// formulario a `ApiClient::update_profile` (PATCH parcial, no PUT — ver
+/// `openapi.yaml` de `Back_App_MotoCarros`).
+#[component]
+fn EditProfileForm(props: EditProfileFormProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut name = use_signal(|| props.user.name.clone());
+    let mut email = use_signal(|| props.user.email.clone());
+    let mut phone = use_signal(|| props.user.phone.clone());
+    let mut update_error = use_signal(|| None::<UpdateProfileError>);
+    let mut is_saving = use_signal(|| false);
+
+    let on_submit = move |event: FormEvent| {
+        event.prevent_default();
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        let payload = UpdateProfilePayload {
+            name: Some(name()),
+            email: Some(email()),
+            phone: Some(phone()),
+        };
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_saving.set(true);
+            update_error.set(None);
+
+            match api_client.update_profile(&token, payload).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    session.set_user(fetch.data);
+                    is_saving.set(false);
+                    props.on_saved.call(());
+                    return;
+                }
+                Err(UpdateProfileError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    update_error.set(Some(err));
+                }
+            }
+
+            is_saving.set(false);
+        });
+    };
+
+    let current_error = update_error();
+    let name_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("name"));
+    let email_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("email"));
+    let phone_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("phone"));
+    // Igual que en el registro (issue #6): el mensaje generico solo se
+    // muestra cuando el error no trae desglose campo por campo, para no
+    // repetir el mismo texto dos veces.
+    let has_field_errors = name_error.is_some() || email_error.is_some() || phone_error.is_some();
+    let general_message = if has_field_errors {
+        None
+    } else {
+        current_error.as_ref().map(|err| err.to_string())
+    };
+
+    rsx! {
+        form { class: "profile-edit-form", onsubmit: on_submit,
+            label { r#for: "profile-edit-name", "Nombre" }
+            input {
+                id: "profile-edit-name",
+                r#type: "text",
+                autocomplete: "name",
+                disabled: is_saving(),
+                value: "{name}",
+                oninput: move |event| name.set(event.value()),
+            }
+            if let Some(message) = &name_error {
+                p { class: "profile-edit-field-error", role: "alert", "{message}" }
+            }
+            label { r#for: "profile-edit-email", "Email" }
+            input {
+                id: "profile-edit-email",
+                r#type: "email",
+                autocomplete: "email",
+                disabled: is_saving(),
+                value: "{email}",
+                oninput: move |event| email.set(event.value()),
+            }
+            if let Some(message) = &email_error {
+                p { class: "profile-edit-field-error", role: "alert", "{message}" }
+            }
+            label { r#for: "profile-edit-phone", "Telefono" }
+            input {
+                id: "profile-edit-phone",
+                r#type: "tel",
+                autocomplete: "tel",
+                disabled: is_saving(),
+                value: "{phone}",
+                oninput: move |event| phone.set(event.value()),
+            }
+            if let Some(message) = &phone_error {
+                p { class: "profile-edit-field-error", role: "alert", "{message}" }
+            }
+            button { r#type: "submit", disabled: is_saving(),
+                if is_saving() {
+                    "Guardando..."
+                } else {
+                    "Guardar cambios"
+                }
+            }
+            button {
+                r#type: "button",
+                disabled: is_saving(),
+                onclick: move |_| props.on_cancel.call(()),
+                "Cancelar"
+            }
+        }
+        if let Some(message) = general_message {
+            p { class: "profile-edit-error", role: "alert", "{message}" }
         }
     }
 }


### PR DESCRIPTION
Closes #10

## Qué hace

- `ApiClient::update_profile` en `moto_core`: `PATCH /api/v1/me` con PATCH parcial real (solo los campos presentes en `UpdateProfilePayload` viajan en el body, vía `skip_serializing_if`), reintento automático con refresh de token ante un 401 (mismo patrón que `get_authenticated`/`me`, issue #3 y #9), y un 422 de validación que nunca se reintenta y se expone como `UpdateProfileError::Validation` con `field_message(...)` por campo (mismo patrón que `RegisterError`).
- Validación local antes de llamar a la API: patch vacío (`NoFields`, ningún campo presente) y formato básico de email/teléfono (reusando `is_valid_email`/`is_valid_phone`, ya usados en el registro), sin duplicar unicidad ni el resto de reglas del backend.
- `ProfileScreen` (`moto_ui`) gana un modo de edición inline en vez de ser una pantalla aparte, tal como pedía el issue ("reusa la misma pantalla/datos como base para editar"): botón "Editar perfil" que muestra un formulario precargado con `session.user()` (nombre, email, teléfono); al guardar llama a `update_profile` con los tres campos del formulario y actualiza `SessionState::set_user` con la respuesta; "Cancelar" vuelve a la vista sin guardar.

## Cómo se probé

- `cargo fmt --all -- --check`, `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`, `cargo test --workspace --exclude mobile` (44 tests en `moto_core`, incluidos 9 nuevos para `update_profile`: patch vacío, email/teléfono inválidos sin request, éxito enviando solo los campos presentes (`body_json` exacto), 422 de validación sin reintento + `field_message`, refresh-y-reintento en 401, `SessionExpired` cuando el refresh también falla, y error de red) y `cargo build --package web --target wasm32-unknown-unknown` — los cuatro en verde.
- No se pudo probar en un navegador real dentro de esta corrida automática (agente sin UI); la cobertura es vía tests de `moto_core` con `wiremock`, siguiendo la Definition of Done del issue.

## Decisiones y riesgos

- El formulario de edición siempre manda los tres campos (nombre, email, teléfono) como `Some(...)`, porque los tres están precargados y visibles en el formulario — es justo la lectura literal de "enviar solo los campos presentes en el formulario". La capa de API (`UpdateProfilePayload`) sí soporta un PATCH parcial real campo por campo (`Option<String>` + `skip_serializing_if`), que es lo que exige el contrato del backend y queda cubierto por tests explícitos.
- Reutilicé `is_valid_email`/`is_valid_phone`, ya definidas en `api.rs` para el registro, en vez de duplicarlas.
- No agregué un mensaje de error específico para "el email ya está en uso" distinto de lo que ya devuelve `field_message("email")` desde el 422 del backend — mismo patrón que el registro de pasajero (#6).