### PR TITLE
feat(#13): ver tarifa estimada antes de solicitar un viaje

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3207,6 +3207,7 @@ version = "0.1.0"
 dependencies = [
  "dioxus",
  "moto_core",
+ "serde",
  "serde_json",
 ]
 

--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -5,8 +5,8 @@
 //! `Back_App_MotoCarros`).
 
 use crate::models::{
-    ApiErrorBody, AuthToken, AuthenticatedUser, DataEnvelope, LoginPayload,
-    RegisterPassengerPayload, UpdateProfilePayload, User,
+    ApiErrorBody, AuthToken, AuthenticatedUser, Coordinates, DataEnvelope, LoginPayload,
+    RegisterPassengerPayload, RideEstimate, RideEstimateRequestPayload, UpdateProfilePayload, User,
 };
 
 #[derive(Debug, Clone)]
@@ -300,12 +300,57 @@ impl UpdateProfileError {
     }
 }
 
+/// Fallos posibles de `POST /api/v1/rides/estimate` (issue #14, consumido
+/// desde la app en issue #13).
+///
+/// `Validation` cubre tanto un 422 de forma (coordenada fuera de rango) como
+/// uno de negocio (el proveedor de mapas no encontro ruta entre origen y
+/// destino, zona sin cobertura): el backend responde el mismo status para
+/// ambos casos a proposito (ver `openapi.yaml`), asi que el cliente no puede
+/// ni debe distinguirlos — el mensaje que trae el body ya es explicito sobre
+/// cual de los dos paso.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EstimateRideError {
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for EstimateRideError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EstimateRideError::Validation(body) => write!(f, "{}", body.message),
+            EstimateRideError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            EstimateRideError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            EstimateRideError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EstimateRideError {}
+
 enum GetOutcome<T> {
     Success(T),
     Unauthorized,
 }
 
 enum PatchOutcome<T> {
+    Success(T),
+    Unauthorized,
+    Validation(ApiErrorBody),
+}
+
+enum PostOutcome<T> {
     Success(T),
     Unauthorized,
     Validation(ApiErrorBody),
@@ -682,6 +727,93 @@ impl ApiClient {
                 Ok(PatchOutcome::Validation(body))
             }
             other => Err(UpdateProfileError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/rides/estimate` — issue #13. No manda nada a `/me`: es
+    /// una consulta puntual, no un sub-recurso de la cuenta (ver
+    /// `openapi.yaml`). Reintenta una vez con refresh de token ante un 401,
+    /// igual que `update_profile`; un 422 (validacion o ruta no encontrada)
+    /// nunca se reintenta.
+    pub async fn estimate_ride(
+        &self,
+        token: &AuthToken,
+        origin: Coordinates,
+        destination: Coordinates,
+    ) -> Result<AuthenticatedFetch<RideEstimate>, EstimateRideError> {
+        let payload = RideEstimateRequestPayload {
+            origin,
+            destination,
+        };
+
+        match self
+            .post_estimate_with_token(&token.access_token, &payload)
+            .await?
+        {
+            PostOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            PostOutcome::Validation(body) => return Err(EstimateRideError::Validation(body)),
+            PostOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| EstimateRideError::SessionExpired)?;
+
+        match self
+            .post_estimate_with_token(&renewed.access_token, &payload)
+            .await?
+        {
+            PostOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            PostOutcome::Validation(body) => Err(EstimateRideError::Validation(body)),
+            PostOutcome::Unauthorized => Err(EstimateRideError::SessionExpired),
+        }
+    }
+
+    async fn post_estimate_with_token(
+        &self,
+        access_token: &str,
+        body: &RideEstimateRequestPayload,
+    ) -> Result<PostOutcome<RideEstimate>, EstimateRideError> {
+        let url = format!("{}/api/v1/rides/estimate", self.base_url);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|err| EstimateRideError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<RideEstimate> = response
+                .json()
+                .await
+                .map_err(|err| EstimateRideError::Network(err.to_string()))?;
+            return Ok(PostOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(PostOutcome::Unauthorized),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| EstimateRideError::Network(err.to_string()))?;
+                Ok(PostOutcome::Validation(body))
+            }
+            other => Err(EstimateRideError::Unexpected(other)),
         }
     }
 }
@@ -1512,5 +1644,187 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, UpdateProfileError::Network(_)));
+    }
+
+    fn sample_origin() -> Coordinates {
+        Coordinates {
+            latitude: 4.710989,
+            longitude: -74.072092,
+        }
+    }
+
+    fn sample_destination() -> Coordinates {
+        Coordinates {
+            latitude: 4.698,
+            longitude: -74.061,
+        }
+    }
+
+    #[tokio::test]
+    async fn estimate_ride_sends_origin_and_destination_and_returns_the_estimate() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/estimate"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .and(body_json(serde_json::json!({
+                "origin": {"latitude": 4.710989, "longitude": -74.072092},
+                "destination": {"latitude": 4.698, "longitude": -74.061},
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "distance_meters": 7421,
+                    "duration_seconds": 842,
+                    "currency": "COP",
+                    "estimated_fare": 8850,
+                    "is_estimate": true,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .estimate_ride(&sample_token(), sample_origin(), sample_destination())
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.distance_meters, 7421);
+        assert_eq!(fetch.data.duration_seconds, 842);
+        assert_eq!(fetch.data.currency, "COP");
+        assert_eq!(fetch.data.estimated_fare, 8850);
+        assert!(fetch.data.is_estimate);
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn estimate_ride_returns_validation_error_on_422_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/estimate"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "No fue posible calcular una ruta entre esas coordenadas. Puede que la zona no este cubierta por el servicio.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .estimate_ride(&sample_token(), sample_origin(), sample_destination())
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            EstimateRideError::Validation(ApiErrorBody {
+                message: "No fue posible calcular una ruta entre esas coordenadas. Puede que la zona no este cubierta por el servicio.".to_string(),
+                errors: None,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn estimate_ride_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/estimate"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/estimate"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "distance_meters": 7421,
+                    "duration_seconds": 842,
+                    "currency": "COP",
+                    "estimated_fare": 8850,
+                    "is_estimate": true,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .estimate_ride(&sample_token(), sample_origin(), sample_destination())
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.distance_meters, 7421);
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn estimate_ride_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/estimate"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .estimate_ride(&sample_token(), sample_origin(), sample_destination())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, EstimateRideError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn estimate_ride_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .estimate_ride(&sample_token(), sample_origin(), sample_destination())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EstimateRideError::Network(_)));
     }
 }

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -91,6 +91,38 @@ pub struct UpdateProfilePayload {
     pub phone: Option<String>,
 }
 
+/// Un punto geografico (`openapi.yaml#/components/schemas/Coordinates`), usado
+/// tanto en el origen como en el destino de `POST /api/v1/rides/estimate`
+/// (issue #13).
+#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
+pub struct Coordinates {
+    pub latitude: f64,
+    pub longitude: f64,
+}
+
+/// Body de `POST /api/v1/rides/estimate`
+/// (`openapi.yaml#/components/schemas/RideEstimateRequest`).
+#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
+pub struct RideEstimateRequestPayload {
+    pub origin: Coordinates,
+    pub destination: Coordinates,
+}
+
+/// `openapi.yaml#/components/schemas/RideEstimate` — respuesta de
+/// `POST /api/v1/rides/estimate` (issue #13).
+///
+/// `estimated_fare` es un entero en la unidad minima de `currency`, nunca un
+/// decimal: el backend nunca lo devuelve fraccionado (ver `FareBreakdown` de
+/// `Back_App_MotoCarros`).
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct RideEstimate {
+    pub distance_meters: u32,
+    pub duration_seconds: u32,
+    pub currency: String,
+    pub estimated_fare: i64,
+    pub is_estimate: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -151,5 +183,50 @@ mod tests {
 
         assert_eq!(error.message, "El email o la contrasena no son correctos.");
         assert!(error.errors.is_none());
+    }
+
+    #[test]
+    fn ride_estimate_request_payload_serializes_origin_and_destination() {
+        let payload = RideEstimateRequestPayload {
+            origin: Coordinates {
+                latitude: 4.710989,
+                longitude: -74.072092,
+            },
+            destination: Coordinates {
+                latitude: 4.698,
+                longitude: -74.061,
+            },
+        };
+
+        let json = serde_json::to_value(payload).unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "origin": {"latitude": 4.710989, "longitude": -74.072092},
+                "destination": {"latitude": 4.698, "longitude": -74.061},
+            })
+        );
+    }
+
+    #[test]
+    fn deserializes_ride_estimate_envelope() {
+        let json = r#"{
+            "data": {
+                "distance_meters": 7421,
+                "duration_seconds": 842,
+                "currency": "COP",
+                "estimated_fare": 8850,
+                "is_estimate": true
+            }
+        }"#;
+
+        let envelope: DataEnvelope<RideEstimate> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(envelope.data.distance_meters, 7421);
+        assert_eq!(envelope.data.duration_seconds, 842);
+        assert_eq!(envelope.data.currency, "COP");
+        assert_eq!(envelope.data.estimated_fare, 8850);
+        assert!(envelope.data.is_estimate);
     }
 }

--- a/crates/moto_ui/Cargo.toml
+++ b/crates/moto_ui/Cargo.toml
@@ -6,4 +6,5 @@ edition.workspace = true
 [dependencies]
 dioxus = { workspace = true }
 moto_core = { path = "../moto_core" }
+serde.workspace = true
 serde_json.workspace = true

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -12,6 +12,7 @@ pub use map::{MapMarker, MapView};
 pub use screens::login::LoginScreen;
 pub use screens::profile::ProfileScreen;
 pub use screens::register_passenger::RegisterPassengerScreen;
+pub use screens::ride_estimate::RideEstimateScreen;
 
 /// Pantallas del flujo de autenticacion, previas a tener sesion iniciada.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -61,15 +62,27 @@ pub fn App() -> Element {
     }
 }
 
-/// Pantalla principal tras iniciar sesion: perfil (issue #9) mas el logout
-/// (issue #8), que no depende de la pantalla de perfil — cerrar sesion debe
-/// estar disponible desde el momento en que hay una sesion iniciada.
+/// Secciones de `Home` una vez hay sesion iniciada. No es un router: es el
+/// mismo patron de navegacion manual por signal que `AuthScreen`, todavia
+/// suficiente para las pocas pantallas que existen (ver
+/// `.claude/STANDARDS.md`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum HomeSection {
+    Profile,
+    RideEstimate,
+}
+
+/// Pantalla principal tras iniciar sesion: perfil (issue #9), tarifa
+/// estimada (issue #13), mas el logout (issue #8), que no depende de ninguna
+/// seccion — cerrar sesion debe estar disponible desde el momento en que hay
+/// una sesion iniciada.
 #[component]
 fn Home() -> Element {
     let api_client = use_context::<ApiClient>();
     let storage = use_context::<Arc<dyn TokenStorage>>();
     let mut session = use_context::<SessionState>();
     let mut is_logging_out = use_signal(|| false);
+    let mut section = use_signal(|| HomeSection::Profile);
 
     let on_logout = move |_| {
         let api_client = api_client.clone();
@@ -97,7 +110,28 @@ fn Home() -> Element {
     rsx! {
         div {
             h1 { "MotoYa" }
-            ProfileScreen {}
+            nav { class: "home-nav",
+                button {
+                    r#type: "button",
+                    disabled: section() == HomeSection::Profile,
+                    onclick: move |_| section.set(HomeSection::Profile),
+                    "Mi perfil"
+                }
+                button {
+                    r#type: "button",
+                    disabled: section() == HomeSection::RideEstimate,
+                    onclick: move |_| section.set(HomeSection::RideEstimate),
+                    "Ver tarifa estimada"
+                }
+            }
+            match section() {
+                HomeSection::Profile => rsx! {
+                    ProfileScreen {}
+                },
+                HomeSection::RideEstimate => rsx! {
+                    RideEstimateScreen {}
+                },
+            }
             button {
                 r#type: "button",
                 disabled: is_logging_out(),

--- a/crates/moto_ui/src/map.rs
+++ b/crates/moto_ui/src/map.rs
@@ -64,9 +64,17 @@ const MAP_INIT_TEMPLATE: &str = r#"
             attribution: "&copy; OpenStreetMap contributors",
         }).addTo(map);
         __MOTOYA_MARKERS__
+        __MOTOYA_CLICK_HANDLER__
     });
 })();
 "#;
+
+/// Se agrega al script solo cuando `MapView` recibe `on_click` (issue #13):
+/// sin el, el mapa no se suscribe a clicks y `dioxus.send` nunca se llama, asi
+/// que el `Eval::recv` del lado de Rust simplemente no tiene nada que leer.
+const CLICK_HANDLER_TEMPLATE: &str = r#"map.on("click", function (e) {
+            dioxus.send({ lat: e.latlng.lat, lng: e.latlng.lng });
+        });"#;
 
 /// Un marcador a dibujar en el mapa. Agnostico de dominio: quien use
 /// `MapView` decide que representa cada marcador (origen, destino,
@@ -105,12 +113,18 @@ fn build_init_script(
     center_lng: f64,
     zoom: u8,
     markers: &[MapMarker],
+    clickable: bool,
 ) -> String {
     let markers_js: String = markers
         .iter()
         .map(MapMarker::to_js_statement)
         .collect::<Vec<_>>()
         .join("\n        ");
+    let click_handler_js = if clickable {
+        CLICK_HANDLER_TEMPLATE
+    } else {
+        ""
+    };
 
     MAP_INIT_TEMPLATE
         .replace("__MOTOYA_LEAFLET_CSS__", LEAFLET_CSS_URL)
@@ -122,6 +136,14 @@ fn build_init_script(
         .replace("__MOTOYA_LNG__", &center_lng.to_string())
         .replace("__MOTOYA_ZOOM__", &zoom.to_string())
         .replace("__MOTOYA_MARKERS__", &markers_js)
+        .replace("__MOTOYA_CLICK_HANDLER__", click_handler_js)
+}
+
+/// Payload que manda `dioxus.send` desde `CLICK_HANDLER_TEMPLATE`.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Deserialize)]
+struct MapClickPayload {
+    lat: f64,
+    lng: f64,
 }
 
 static MAP_INSTANCE_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -136,6 +158,11 @@ fn next_map_id() -> String {
 /// via `dioxus::document::eval`, que funciona tanto en el build web (WASM)
 /// como en renderers basados en webview.
 ///
+/// `on_click`, si se pasa, se llama con `(lat, lng)` cada vez que el usuario
+/// hace click en el mapa (issue #13: elegir origen/destino de un viaje).
+/// Sigue siendo agnostico de dominio — no sabe que representa el punto
+/// elegido, eso lo decide quien use `MapView`.
+///
 /// Limitacion conocida (documentada, no un descuido): la inicializacion
 /// corre una sola vez al montar el componente, igual que el patron ya usado
 /// en `App::hydrate` (ver `moto_ui/src/lib.rs`). Si `center`/`zoom`/
@@ -148,14 +175,30 @@ pub fn MapView(
     center_lng: f64,
     #[props(default = 13)] zoom: u8,
     #[props(default = Vec::new())] markers: Vec<MapMarker>,
+    #[props(default)] on_click: Option<EventHandler<(f64, f64)>>,
 ) -> Element {
     let map_id = use_hook(next_map_id);
 
     {
         let map_id = map_id.clone();
         use_effect(move || {
-            let script = build_init_script(&map_id, center_lat, center_lng, zoom, &markers);
-            document::eval(&script);
+            let script = build_init_script(
+                &map_id,
+                center_lat,
+                center_lng,
+                zoom,
+                &markers,
+                on_click.is_some(),
+            );
+            let mut eval = document::eval(&script);
+
+            if let Some(on_click) = on_click {
+                spawn(async move {
+                    while let Ok(payload) = eval.recv::<MapClickPayload>().await {
+                        on_click.call((payload.lat, payload.lng));
+                    }
+                });
+            }
         });
     }
 
@@ -174,7 +217,7 @@ mod tests {
 
     #[test]
     fn build_init_script_embeds_id_center_and_zoom() {
-        let script = build_init_script("motoya-map-0", 4.710989, -74.072092, 15, &[]);
+        let script = build_init_script("motoya-map-0", 4.710989, -74.072092, 15, &[], false);
 
         assert!(script.contains(r#"document.getElementById("motoya-map-0")"#));
         assert!(script.contains("setView([4.710989, -74.072092], 15)"));
@@ -184,7 +227,7 @@ mod tests {
 
     #[test]
     fn build_init_script_sets_sri_integrity_and_crossorigin_on_css_and_js() {
-        let script = build_init_script("motoya-map-0", 0.0, 0.0, 13, &[]);
+        let script = build_init_script("motoya-map-0", 0.0, 0.0, 13, &[], false);
 
         assert!(script.contains(&format!(r#"cssLink.integrity = "{LEAFLET_CSS_INTEGRITY}""#)));
         assert!(script.contains(&format!(r#"script.integrity = "{LEAFLET_JS_INTEGRITY}""#)));
@@ -194,7 +237,7 @@ mod tests {
 
     #[test]
     fn build_init_script_with_no_markers_has_no_marker_statements() {
-        let script = build_init_script("motoya-map-0", 0.0, 0.0, 13, &[]);
+        let script = build_init_script("motoya-map-0", 0.0, 0.0, 13, &[], false);
 
         assert!(!script.contains("L.marker"));
     }
@@ -214,7 +257,7 @@ mod tests {
             },
         ];
 
-        let script = build_init_script("motoya-map-1", 4.71, -74.07, 13, &markers);
+        let script = build_init_script("motoya-map-1", 4.71, -74.07, 13, &markers, false);
 
         assert_eq!(script.matches("L.marker(").count(), 2);
         assert!(script.contains("L.marker([4.71, -74.07]).bindPopup(\"Origen\").addTo(map);"));
@@ -229,11 +272,27 @@ mod tests {
             label: Some(r#""); alert("xss"); ("#.to_string()),
         }];
 
-        let script = build_init_script("motoya-map-2", 1.0, 2.0, 13, &markers);
+        let script = build_init_script("motoya-map-2", 1.0, 2.0, 13, &markers, false);
 
         // El label queda como un literal JSON escapado (comillas escapadas
         // con `\"`), no como codigo JS suelto que rompa fuera del string.
         assert!(script.contains(r#".bindPopup("\"); alert(\"xss\"); (")"#));
+    }
+
+    #[test]
+    fn build_init_script_without_on_click_has_no_click_handler() {
+        let script = build_init_script("motoya-map-0", 0.0, 0.0, 13, &[], false);
+
+        assert!(!script.contains("map.on(\"click\""));
+        assert!(!script.contains("dioxus.send"));
+    }
+
+    #[test]
+    fn build_init_script_with_on_click_binds_a_click_handler_that_sends_lat_lng() {
+        let script = build_init_script("motoya-map-0", 0.0, 0.0, 13, &[], true);
+
+        assert!(script.contains("map.on(\"click\""));
+        assert!(script.contains("dioxus.send({ lat: e.latlng.lat, lng: e.latlng.lng });"));
     }
 
     #[test]

--- a/crates/moto_ui/src/screens/mod.rs
+++ b/crates/moto_ui/src/screens/mod.rs
@@ -1,3 +1,4 @@
 pub mod login;
 pub mod profile;
 pub mod register_passenger;
+pub mod ride_estimate;

--- a/crates/moto_ui/src/screens/ride_estimate.rs
+++ b/crates/moto_ui/src/screens/ride_estimate.rs
@@ -1,0 +1,189 @@
+//! Pantalla de tarifa estimada (pasajero) — issue #13.
+//!
+//! Consume `POST /api/v1/rides/estimate` a traves de
+//! `ApiClient::estimate_ride`. No solicita el viaje ni persiste nada: es solo
+//! una consulta para que el pasajero decida si continua. Para pedir el viaje
+//! de verdad esta `POST /rides` (historia #15), que vuelve a calcular estos
+//! mismos numeros.
+//!
+//! Origen y destino se eligen tocando el mapa (`MapView::on_click`, ver
+//! `moto_ui/src/map.rs`), no con campos de texto: la historia depende
+//! explicitamente del componente de mapa (issue #4).
+
+use std::sync::Arc;
+
+use dioxus::prelude::*;
+use moto_core::api::{ApiClient, EstimateRideError};
+use moto_core::models::{Coordinates, RideEstimate};
+use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
+
+use crate::map::{MapMarker, MapView};
+
+/// Centro inicial del mapa mientras no exista geolocalizacion del
+/// dispositivo (fuera de alcance de este issue): Bogota, el mismo punto que
+/// ya usan los ejemplos de `openapi.yaml`.
+const DEFAULT_CENTER_LAT: f64 = 4.710989;
+const DEFAULT_CENTER_LNG: f64 = -74.072092;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum PickTarget {
+    Origin,
+    Destination,
+}
+
+#[component]
+pub fn RideEstimateScreen() -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut origin = use_signal(|| None::<(f64, f64)>);
+    let mut destination = use_signal(|| None::<(f64, f64)>);
+    let mut pick_target = use_signal(|| PickTarget::Origin);
+    let mut estimate_error = use_signal(|| None::<EstimateRideError>);
+    let mut estimate = use_signal(|| None::<RideEstimate>);
+    let mut is_loading = use_signal(|| false);
+
+    let on_map_click = move |(lat, lng): (f64, f64)| {
+        estimate.set(None);
+        estimate_error.set(None);
+
+        match pick_target() {
+            PickTarget::Origin => {
+                origin.set(Some((lat, lng)));
+                pick_target.set(PickTarget::Destination);
+            }
+            PickTarget::Destination => {
+                destination.set(Some((lat, lng)));
+            }
+        }
+    };
+
+    let on_estimate_click = move |_| {
+        let Some(token) = session.token() else {
+            return;
+        };
+        let Some((origin_lat, origin_lng)) = origin() else {
+            return;
+        };
+        let Some((destination_lat, destination_lng)) = destination() else {
+            return;
+        };
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            estimate_error.set(None);
+
+            let origin_coords = Coordinates {
+                latitude: origin_lat,
+                longitude: origin_lng,
+            };
+            let destination_coords = Coordinates {
+                latitude: destination_lat,
+                longitude: destination_lng,
+            };
+
+            match api_client
+                .estimate_ride(&token, origin_coords, destination_coords)
+                .await
+            {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    estimate.set(Some(fetch.data));
+                }
+                Err(EstimateRideError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    estimate_error.set(Some(err));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    };
+
+    let markers: Vec<MapMarker> = [
+        origin().map(|(lat, lng)| MapMarker {
+            lat,
+            lng,
+            label: Some("Origen".to_string()),
+        }),
+        destination().map(|(lat, lng)| MapMarker {
+            lat,
+            lng,
+            label: Some("Destino".to_string()),
+        }),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    let can_estimate = origin().is_some() && destination().is_some();
+
+    let instructions = match pick_target() {
+        PickTarget::Origin => "Toca el mapa para elegir el origen.",
+        PickTarget::Destination => "Toca el mapa para elegir el destino.",
+    };
+
+    rsx! {
+        div { class: "ride-estimate-screen",
+            h2 { "Ver tarifa estimada" }
+            p { class: "ride-estimate-instructions", "{instructions}" }
+            div { class: "ride-estimate-target-buttons",
+                button {
+                    r#type: "button",
+                    disabled: pick_target() == PickTarget::Origin,
+                    onclick: move |_| pick_target.set(PickTarget::Origin),
+                    "Elegir origen"
+                }
+                button {
+                    r#type: "button",
+                    disabled: pick_target() == PickTarget::Destination,
+                    onclick: move |_| pick_target.set(PickTarget::Destination),
+                    "Elegir destino"
+                }
+            }
+            div { class: "ride-estimate-map", style: "height: 320px;",
+                MapView {
+                    center_lat: DEFAULT_CENTER_LAT,
+                    center_lng: DEFAULT_CENTER_LNG,
+                    markers,
+                    on_click: on_map_click,
+                }
+            }
+            button {
+                r#type: "button",
+                class: "ride-estimate-button",
+                disabled: !can_estimate || is_loading(),
+                onclick: on_estimate_click,
+                if is_loading() {
+                    "Calculando..."
+                } else {
+                    "Ver tarifa estimada"
+                }
+            }
+            if let Some(err) = estimate_error() {
+                p { class: "ride-estimate-error", role: "alert", "{err}" }
+            } else if let Some(value) = estimate() {
+                dl { class: "ride-estimate-result",
+                    dt { "Distancia" }
+                    dd { "{value.distance_meters} m" }
+                    dt { "Duracion" }
+                    dd { "{value.duration_seconds / 60} min" }
+                    dt { "Tarifa estimada" }
+                    dd { "{value.currency} {value.estimated_fare}" }
+                }
+            } else if !can_estimate {
+                p { class: "ride-estimate-empty",
+                    "Elige un origen y un destino en el mapa para ver la tarifa."
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #13

## Qué hace

Como pasajero, permite ver una tarifa estimada (distancia, duración y
costo) antes de solicitar un viaje, eligiendo origen y destino
directamente en el mapa.

- `ApiClient::estimate_ride` (`moto_core/src/api.rs`): `POST
  /api/v1/rides/estimate`, autenticado, con el mismo patrón de
  reintento por refresh de token en un 401 que ya usa
  `update_profile`. Un 422 (validación de forma o "no se encontró
  ruta") nunca se reintenta y se propaga tal cual lo manda el backend.
- Modelos nuevos en `moto_core/src/models.rs`: `Coordinates`,
  `RideEstimateRequestPayload` (body) y `RideEstimate` (respuesta),
  reflejando el contrato de `openapi.yaml` de `Back_App_MotoCarros`
  (`distance_meters`, `duration_seconds`, `currency`,
  `estimated_fare`, `is_estimate`).
- `MapView` (`moto_ui/src/map.rs`) gana un prop opcional `on_click:
  Option<EventHandler<(f64, f64)>>`: cuando se pasa, el script Leaflet
  suscribe `map.on("click", ...)` y manda el punto de vuelta a Rust
  con `dioxus.send`/`Eval::recv`. Sigue siendo un componente agnóstico
  de dominio — no sabe qué representa el punto elegido.
- `RideEstimateScreen` (`moto_ui/src/screens/ride_estimate.rs`): el
  pasajero alterna entre elegir origen/destino tocando el mapa, ve los
  marcadores correspondientes, y el botón "Ver tarifa estimada" queda
  deshabilitado hasta tener ambos puntos.
- `Home` (`moto_ui/src/lib.rs`) gana una navegación mínima
  (perfil / tarifa estimada) para que la pantalla sea alcanzable.

## Cómo se probó

- `cargo test --workspace --exclude mobile`: 59 tests en verde,
  incluyendo los nuevos casos de `estimate_ride` (éxito, validación
  422 sin reintento, retry-on-401, sesión expirada, error de red) y de
  `MapView` (script con/sin el handler de click).
- `cargo fmt --all -- --check`: sin diferencias.
- `cargo clippy --workspace --exclude mobile --all-targets
  --all-features -- -D warnings`: sin warnings.
- `cargo build --package web --target wasm32-unknown-unknown`: build
  verde.
- No se corrió el build móvil (APK/IPA): el issue no toca código
  específico de plataforma móvil.

## Decisiones y riesgos

- El criterio de aceptación pide elegir origen/destino "en el mapa",
  no con campos de texto — por eso se extendió `MapView` con clicks en
  vez de agregar inputs de lat/lng. Es la primera vez que el
  componente deja de ser puramente pasivo; se documentó la extensión
  en su propio doc-comment para que la próxima historia que lo toque
  (tracking en tiempo real) sepa que ese canal ya existe.
- El centro inicial del mapa es un punto fijo en Bogotá (mismo que usa
  `openapi.yaml` de ejemplo) porque todavía no hay geolocalización del
  dispositivo — eso queda fuera de alcance de este issue.
- La navegación en `Home` es el mismo patrón manual por signal que ya
  existía para pantallas de auth (no hay router todavía), agregado acá
  solo para que la pantalla sea alcanzable, sin ampliar su alcance.