### PR TITLE
feat(#14): solicitar un viaje

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -6,7 +6,8 @@
 
 use crate::models::{
     ApiErrorBody, AuthToken, AuthenticatedUser, Coordinates, DataEnvelope, LoginPayload,
-    RegisterPassengerPayload, RideEstimate, RideEstimateRequestPayload, UpdateProfilePayload, User,
+    RegisterPassengerPayload, Ride, RideEstimate, RideEstimateRequestPayload, RideRequestPayload,
+    UpdateProfilePayload, User,
 };
 
 #[derive(Debug, Clone)]
@@ -339,6 +340,50 @@ impl std::fmt::Display for EstimateRideError {
 
 impl std::error::Error for EstimateRideError {}
 
+/// Fallos posibles de `POST /api/v1/rides` (issue #14).
+///
+/// `Validation` cubre tanto un 422 de forma (coordenada invalida) como uno de
+/// negocio (el pasajero ya tiene un viaje activo, o el proveedor de mapas no
+/// encontro ruta): el backend responde el mismo status para ambos casos a
+/// proposito (ver `openapi.yaml`), asi que el cliente no puede ni debe
+/// distinguirlos — el mensaje que trae el body ya es explicito sobre cual de
+/// los dos paso.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RequestRideError {
+    /// La cuenta no es de pasajero (`RidePolicy` en el backend). Solicitar un
+    /// viaje es una operacion exclusiva del rol pasajero.
+    Forbidden,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for RequestRideError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequestRideError::Forbidden => {
+                write!(f, "Esta cuenta no puede solicitar viajes.")
+            }
+            RequestRideError::Validation(body) => write!(f, "{}", body.message),
+            RequestRideError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            RequestRideError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            RequestRideError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RequestRideError {}
+
 enum GetOutcome<T> {
     Success(T),
     Unauthorized,
@@ -353,6 +398,13 @@ enum PatchOutcome<T> {
 enum PostOutcome<T> {
     Success(T),
     Unauthorized,
+    Validation(ApiErrorBody),
+}
+
+enum PostRideOutcome<T> {
+    Success(T),
+    Unauthorized,
+    Forbidden,
     Validation(ApiErrorBody),
 }
 
@@ -814,6 +866,97 @@ impl ApiClient {
                 Ok(PostOutcome::Validation(body))
             }
             other => Err(EstimateRideError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/rides` — issue #14. Manda el mismo par de coordenadas
+    /// que `estimate_ride`: el backend vuelve a calcular distancia, duracion
+    /// y tarifa al crear el viaje, no reutiliza el estimado anterior.
+    /// Reintenta una vez con refresh de token ante un 401, igual que
+    /// `estimate_ride`; un 403 (cuenta no pasajero) o un 422 (validacion o
+    /// viaje activo ya existente) nunca se reintentan.
+    pub async fn request_ride(
+        &self,
+        token: &AuthToken,
+        origin: Coordinates,
+        destination: Coordinates,
+    ) -> Result<AuthenticatedFetch<Ride>, RequestRideError> {
+        let payload = RideRequestPayload {
+            origin,
+            destination,
+        };
+
+        match self
+            .post_ride_with_token(&token.access_token, &payload)
+            .await?
+        {
+            PostRideOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            PostRideOutcome::Forbidden => return Err(RequestRideError::Forbidden),
+            PostRideOutcome::Validation(body) => return Err(RequestRideError::Validation(body)),
+            PostRideOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| RequestRideError::SessionExpired)?;
+
+        match self
+            .post_ride_with_token(&renewed.access_token, &payload)
+            .await?
+        {
+            PostRideOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            PostRideOutcome::Forbidden => Err(RequestRideError::Forbidden),
+            PostRideOutcome::Validation(body) => Err(RequestRideError::Validation(body)),
+            PostRideOutcome::Unauthorized => Err(RequestRideError::SessionExpired),
+        }
+    }
+
+    async fn post_ride_with_token(
+        &self,
+        access_token: &str,
+        body: &RideRequestPayload,
+    ) -> Result<PostRideOutcome<Ride>, RequestRideError> {
+        let url = format!("{}/api/v1/rides", self.base_url);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|err| RequestRideError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<Ride> = response
+                .json()
+                .await
+                .map_err(|err| RequestRideError::Network(err.to_string()))?;
+            return Ok(PostRideOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(PostRideOutcome::Unauthorized),
+            403 => Ok(PostRideOutcome::Forbidden),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| RequestRideError::Network(err.to_string()))?;
+                Ok(PostRideOutcome::Validation(body))
+            }
+            other => Err(RequestRideError::Unexpected(other)),
         }
     }
 }
@@ -1826,5 +1969,209 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, EstimateRideError::Network(_)));
+    }
+
+    fn sample_ride_json() -> serde_json::Value {
+        serde_json::json!({
+            "id": 1,
+            "status": "requested",
+            "origin": {"latitude": 4.710989, "longitude": -74.072092},
+            "destination": {"latitude": 4.698, "longitude": -74.061},
+            "distance_meters": 7421,
+            "duration_seconds": 842,
+            "currency": "COP",
+            "estimated_fare": 8850,
+            "driver": null,
+            "requested_at": "2026-07-31T14:03:21+00:00",
+            "started_at": null,
+            "completed_at": null,
+            "final_fare": null,
+            "payment": null,
+        })
+    }
+
+    #[tokio::test]
+    async fn request_ride_sends_origin_and_destination_and_returns_the_created_ride() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .and(body_json(serde_json::json!({
+                "origin": {"latitude": 4.710989, "longitude": -74.072092},
+                "destination": {"latitude": 4.698, "longitude": -74.061},
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "data": sample_ride_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .request_ride(&sample_token(), sample_origin(), sample_destination())
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.id, 1);
+        assert_eq!(fetch.data.status, crate::models::RideStatus::Requested);
+        assert_eq!(fetch.data.estimated_fare, 8850);
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn request_ride_returns_forbidden_on_403_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .request_ride(&sample_token(), sample_origin(), sample_destination())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, RequestRideError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn request_ride_returns_validation_error_on_422_when_an_active_ride_already_exists() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Ya tienes un viaje en curso; terminalo o cancelalo antes de solicitar otro.",
+                "errors": {
+                    "ride": ["Ya tienes un viaje en curso; terminalo o cancelalo antes de solicitar otro."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .request_ride(&sample_token(), sample_origin(), sample_destination())
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            RequestRideError::Validation(ApiErrorBody {
+                message: "Ya tienes un viaje en curso; terminalo o cancelalo antes de solicitar otro."
+                    .to_string(),
+                errors: Some(HashMap::from([(
+                    "ride".to_string(),
+                    vec![
+                        "Ya tienes un viaje en curso; terminalo o cancelalo antes de solicitar otro."
+                            .to_string()
+                    ]
+                )])),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn request_ride_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "data": sample_ride_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .request_ride(&sample_token(), sample_origin(), sample_destination())
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.id, 1);
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn request_ride_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .request_ride(&sample_token(), sample_origin(), sample_destination())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, RequestRideError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn request_ride_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .request_ride(&sample_token(), sample_origin(), sample_destination())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RequestRideError::Network(_)));
     }
 }

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -93,8 +93,8 @@ pub struct UpdateProfilePayload {
 
 /// Un punto geografico (`openapi.yaml#/components/schemas/Coordinates`), usado
 /// tanto en el origen como en el destino de `POST /api/v1/rides/estimate`
-/// (issue #13).
-#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
+/// (issue #13) y de `POST /api/v1/rides` (issue #14).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct Coordinates {
     pub latitude: f64,
     pub longitude: f64,
@@ -121,6 +121,78 @@ pub struct RideEstimate {
     pub currency: String,
     pub estimated_fare: i64,
     pub is_estimate: bool,
+}
+
+/// Estado de un viaje (`openapi.yaml#/components/schemas/Ride.status`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RideStatus {
+    Requested,
+    Accepted,
+    InProgress,
+    Completed,
+    Cancelled,
+}
+
+/// Body de `POST /api/v1/rides`
+/// (`openapi.yaml#/components/schemas/RideRequest`).
+///
+/// Misma forma que `RideEstimateRequestPayload` a proposito (el backend lo
+/// documenta asi para que la app mande el mismo cuerpo con el que estimo la
+/// tarifa), pero es un tipo aparte porque son la entrada de dos operaciones
+/// distintas que pueden divergir mas adelante (issue #14).
+#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
+pub struct RideRequestPayload {
+    pub origin: Coordinates,
+    pub destination: Coordinates,
+}
+
+/// `openapi.yaml#/components/schemas/RideDriver` — el conductor asignado a un
+/// viaje, visto desde el viaje. `None` mientras nadie lo haya aceptado
+/// todavia (historia #17, fuera de alcance de #14).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RideDriver {
+    pub id: u64,
+    pub name: String,
+}
+
+/// Resultado del cobro de un viaje completado
+/// (`openapi.yaml#/components/schemas/Payment`, historia #25).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PaymentStatus {
+    Pending,
+    Paid,
+    Failed,
+}
+
+/// `openapi.yaml#/components/schemas/Payment`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Payment {
+    pub status: PaymentStatus,
+}
+
+/// `openapi.yaml#/components/schemas/Ride` — respuesta de `POST /api/v1/rides`
+/// (issue #14). `driver`, `started_at`, `completed_at`, `final_fare` y
+/// `payment` viajan siempre presentes pero en `null` hasta que la historia
+/// correspondiente los produzca (aceptar #17, iniciar #18, completar #23,
+/// pagar #24) — por eso son `Option` en vez de campos opcionales del struct.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct Ride {
+    pub id: u64,
+    pub status: RideStatus,
+    pub origin: Coordinates,
+    pub destination: Coordinates,
+    pub distance_meters: u32,
+    pub duration_seconds: u32,
+    pub currency: String,
+    pub estimated_fare: i64,
+    pub driver: Option<RideDriver>,
+    pub requested_at: String,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub final_fare: Option<i64>,
+    pub payment: Option<Payment>,
 }
 
 #[cfg(test)]
@@ -228,5 +300,97 @@ mod tests {
         assert_eq!(envelope.data.currency, "COP");
         assert_eq!(envelope.data.estimated_fare, 8850);
         assert!(envelope.data.is_estimate);
+    }
+
+    #[test]
+    fn ride_request_payload_serializes_origin_and_destination() {
+        let payload = RideRequestPayload {
+            origin: Coordinates {
+                latitude: 4.710989,
+                longitude: -74.072092,
+            },
+            destination: Coordinates {
+                latitude: 4.698,
+                longitude: -74.061,
+            },
+        };
+
+        let json = serde_json::to_value(payload).unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "origin": {"latitude": 4.710989, "longitude": -74.072092},
+                "destination": {"latitude": 4.698, "longitude": -74.061},
+            })
+        );
+    }
+
+    #[test]
+    fn deserializes_ride_envelope_with_no_driver_yet() {
+        let json = r#"{
+            "data": {
+                "id": 1,
+                "status": "requested",
+                "origin": {"latitude": 4.710989, "longitude": -74.072092},
+                "destination": {"latitude": 4.698, "longitude": -74.061},
+                "distance_meters": 7421,
+                "duration_seconds": 842,
+                "currency": "COP",
+                "estimated_fare": 8850,
+                "driver": null,
+                "requested_at": "2026-07-31T14:03:21+00:00",
+                "started_at": null,
+                "completed_at": null,
+                "final_fare": null,
+                "payment": null
+            }
+        }"#;
+
+        let envelope: DataEnvelope<Ride> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(envelope.data.id, 1);
+        assert_eq!(envelope.data.status, RideStatus::Requested);
+        assert_eq!(envelope.data.estimated_fare, 8850);
+        assert_eq!(envelope.data.driver, None);
+        assert_eq!(envelope.data.started_at, None);
+        assert_eq!(envelope.data.payment, None);
+    }
+
+    #[test]
+    fn deserializes_ride_with_an_assigned_driver_and_payment() {
+        let json = r#"{
+            "id": 1,
+            "status": "completed",
+            "origin": {"latitude": 4.710989, "longitude": -74.072092},
+            "destination": {"latitude": 4.698, "longitude": -74.061},
+            "distance_meters": 7421,
+            "duration_seconds": 842,
+            "currency": "COP",
+            "estimated_fare": 8850,
+            "driver": {"id": 42, "name": "Carlos Perez"},
+            "requested_at": "2026-07-31T14:03:21+00:00",
+            "started_at": "2026-07-31T14:05:00+00:00",
+            "completed_at": "2026-07-31T14:20:00+00:00",
+            "final_fare": 9100,
+            "payment": {"status": "paid"}
+        }"#;
+
+        let ride: Ride = serde_json::from_str(json).unwrap();
+
+        assert_eq!(ride.status, RideStatus::Completed);
+        assert_eq!(
+            ride.driver,
+            Some(RideDriver {
+                id: 42,
+                name: "Carlos Perez".to_string(),
+            })
+        );
+        assert_eq!(
+            ride.payment,
+            Some(Payment {
+                status: PaymentStatus::Paid,
+            })
+        );
     }
 }

--- a/crates/moto_ui/src/screens/ride_estimate.rs
+++ b/crates/moto_ui/src/screens/ride_estimate.rs
@@ -1,10 +1,14 @@
-//! Pantalla de tarifa estimada (pasajero) — issue #13.
+//! Pantalla de tarifa estimada y solicitud de viaje (pasajero) — issues #13
+//! y #14.
 //!
-//! Consume `POST /api/v1/rides/estimate` a traves de
-//! `ApiClient::estimate_ride`. No solicita el viaje ni persiste nada: es solo
-//! una consulta para que el pasajero decida si continua. Para pedir el viaje
-//! de verdad esta `POST /rides` (historia #15), que vuelve a calcular estos
-//! mismos numeros.
+//! Consume `POST /api/v1/rides/estimate` (`ApiClient::estimate_ride`) para la
+//! tarifa estimada, sin solicitar nada todavia. Una vez que hay una
+//! estimacion, el pasajero puede confirmar y solicitar el viaje de verdad
+//! con `POST /api/v1/rides` (`ApiClient::request_ride`, issue #14) — el
+//! backend vuelve a calcular estos mismos numeros al crear el viaje. Mientras
+//! el viaje solicitado sigue activo, esta pantalla no vuelve a ofrecer el
+//! flujo de estimar/solicitar (un pasajero solo puede tener un viaje activo a
+//! la vez, ver `openapi.yaml`).
 //!
 //! Origen y destino se eligen tocando el mapa (`MapView::on_click`, ver
 //! `moto_ui/src/map.rs`), no con campos de texto: la historia depende
@@ -13,8 +17,8 @@
 use std::sync::Arc;
 
 use dioxus::prelude::*;
-use moto_core::api::{ApiClient, EstimateRideError};
-use moto_core::models::{Coordinates, RideEstimate};
+use moto_core::api::{ApiClient, EstimateRideError, RequestRideError};
+use moto_core::models::{Coordinates, Ride, RideEstimate, RideStatus};
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
 
@@ -44,6 +48,9 @@ pub fn RideEstimateScreen() -> Element {
     let mut estimate_error = use_signal(|| None::<EstimateRideError>);
     let mut estimate = use_signal(|| None::<RideEstimate>);
     let mut is_loading = use_signal(|| false);
+    let mut ride_error = use_signal(|| None::<RequestRideError>);
+    let mut requested_ride = use_signal(|| None::<Ride>);
+    let mut is_requesting = use_signal(|| false);
 
     let on_map_click = move |(lat, lng): (f64, f64)| {
         estimate.set(None);
@@ -60,7 +67,59 @@ pub fn RideEstimateScreen() -> Element {
         }
     };
 
-    let on_estimate_click = move |_| {
+    let on_estimate_click = {
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+        move |_| {
+            let Some(token) = session.token() else {
+                return;
+            };
+            let Some((origin_lat, origin_lng)) = origin() else {
+                return;
+            };
+            let Some((destination_lat, destination_lng)) = destination() else {
+                return;
+            };
+            let api_client = api_client.clone();
+            let storage = storage.clone();
+
+            spawn(async move {
+                is_loading.set(true);
+                estimate_error.set(None);
+
+                let origin_coords = Coordinates {
+                    latitude: origin_lat,
+                    longitude: origin_lng,
+                };
+                let destination_coords = Coordinates {
+                    latitude: destination_lat,
+                    longitude: destination_lng,
+                };
+
+                match api_client
+                    .estimate_ride(&token, origin_coords, destination_coords)
+                    .await
+                {
+                    Ok(fetch) => {
+                        if let Some(refreshed) = fetch.refreshed_token {
+                            session.update_token(refreshed, storage.as_ref());
+                        }
+                        estimate.set(Some(fetch.data));
+                    }
+                    Err(EstimateRideError::SessionExpired) => {
+                        session.logout(storage.as_ref());
+                    }
+                    Err(err) => {
+                        estimate_error.set(Some(err));
+                    }
+                }
+
+                is_loading.set(false);
+            });
+        }
+    };
+
+    let on_request_click = move |_| {
         let Some(token) = session.token() else {
             return;
         };
@@ -74,8 +133,8 @@ pub fn RideEstimateScreen() -> Element {
         let storage = storage.clone();
 
         spawn(async move {
-            is_loading.set(true);
-            estimate_error.set(None);
+            is_requesting.set(true);
+            ride_error.set(None);
 
             let origin_coords = Coordinates {
                 latitude: origin_lat,
@@ -87,24 +146,24 @@ pub fn RideEstimateScreen() -> Element {
             };
 
             match api_client
-                .estimate_ride(&token, origin_coords, destination_coords)
+                .request_ride(&token, origin_coords, destination_coords)
                 .await
             {
                 Ok(fetch) => {
                     if let Some(refreshed) = fetch.refreshed_token {
                         session.update_token(refreshed, storage.as_ref());
                     }
-                    estimate.set(Some(fetch.data));
+                    requested_ride.set(Some(fetch.data));
                 }
-                Err(EstimateRideError::SessionExpired) => {
+                Err(RequestRideError::SessionExpired) => {
                     session.logout(storage.as_ref());
                 }
                 Err(err) => {
-                    estimate_error.set(Some(err));
+                    ride_error.set(Some(err));
                 }
             }
 
-            is_loading.set(false);
+            is_requesting.set(false);
         });
     };
 
@@ -130,6 +189,23 @@ pub fn RideEstimateScreen() -> Element {
         PickTarget::Origin => "Toca el mapa para elegir el origen.",
         PickTarget::Destination => "Toca el mapa para elegir el destino.",
     };
+
+    if let Some(ride) = requested_ride() {
+        return rsx! {
+            div { class: "ride-estimate-screen",
+                h2 { "Viaje solicitado" }
+                p { class: "ride-request-status", "{ride_status_label(ride.status)}" }
+                dl { class: "ride-request-result",
+                    dt { "Distancia" }
+                    dd { "{ride.distance_meters} m" }
+                    dt { "Duracion" }
+                    dd { "{ride.duration_seconds / 60} min" }
+                    dt { "Tarifa estimada" }
+                    dd { "{ride.currency} {ride.estimated_fare}" }
+                }
+            }
+        };
+    }
 
     rsx! {
         div { class: "ride-estimate-screen",
@@ -179,11 +255,40 @@ pub fn RideEstimateScreen() -> Element {
                     dt { "Tarifa estimada" }
                     dd { "{value.currency} {value.estimated_fare}" }
                 }
+                button {
+                    r#type: "button",
+                    class: "ride-request-button",
+                    disabled: is_requesting(),
+                    onclick: on_request_click,
+                    if is_requesting() {
+                        "Solicitando..."
+                    } else {
+                        "Confirmar y solicitar viaje"
+                    }
+                }
+                if let Some(err) = ride_error() {
+                    p { class: "ride-request-error", role: "alert", "{err}" }
+                }
             } else if !can_estimate {
                 p { class: "ride-estimate-empty",
                     "Elige un origen y un destino en el mapa para ver la tarifa."
                 }
             }
         }
+    }
+}
+
+/// Texto para el pasajero segun el estado del viaje recien solicitado
+/// (`Ride::status`). Justo despues de `POST /api/v1/rides` el viaje siempre
+/// nace `requested`; los demas casos quedan cubiertos para cuando esta misma
+/// pantalla se reutilice con datos de un viaje ya en curso (historia #20,
+/// fuera de alcance de #14).
+fn ride_status_label(status: RideStatus) -> &'static str {
+    match status {
+        RideStatus::Requested => "Esperando a que un conductor lo acepte.",
+        RideStatus::Accepted => "Un conductor acepto tu viaje.",
+        RideStatus::InProgress => "Tu viaje esta en curso.",
+        RideStatus::Completed => "Tu viaje ya se completo.",
+        RideStatus::Cancelled => "Este viaje fue cancelado.",
     }
 }


### PR DESCRIPTION
Closes #14

## Qué hace

- Agrega `ApiClient::request_ride` en `moto_core::api` (`POST /api/v1/rides`), con el mismo patrón de reintento por refresh-on-401 que `estimate_ride`, y sin reintento ante 403 (cuenta no pasajero) ni 422 (validación o viaje activo ya existente, ver `openapi.yaml`).
- Agrega `RequestRideError` (`Forbidden`, `Validation`, `SessionExpired`, `Network`, `Unexpected`).
- Agrega los modelos que reflejan el contrato de `Ride` (`openapi.yaml#/components/schemas/Ride`): `RideStatus`, `RideRequestPayload`, `RideDriver`, `Payment`/`PaymentStatus`, `Ride`. `Coordinates` ahora también deriva `Deserialize` porque `Ride.origin`/`destination` vienen en la respuesta.
- Extiende `RideEstimateScreen` (issue #13): una vez que hay una tarifa estimada, aparece un botón "Confirmar y solicitar viaje" que llama a `request_ride` con el mismo origen/destino. Si el backend responde éxito, la pantalla pasa a mostrar el viaje solicitado (estado, distancia, duración, tarifa) y deja de ofrecer el flujo de estimar/solicitar — un pasajero solo puede tener un viaje activo a la vez. Un error de validación (422, incluyendo "ya tienes un viaje en curso") se muestra sin perder el origen/destino/estimación ya cargados.

## Cómo se probó

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude mobile` (68 tests, incluye 6 tests nuevos de `request_ride` en `moto_core::api` con `wiremock`: éxito, 403, 422 por viaje activo, retry-on-401, session-expired, network error; más 3 tests nuevos de (de)serialización en `moto_core::models`)
- `cargo build --package web --target wasm32-unknown-unknown`

No se probó manualmente en navegador (fuera del alcance de esta corrida automatizada); la lógica de negocio y el cliente API sí quedan cubiertos por tests, según `.claude/STANDARDS.md`.

## Decisiones y riesgos

- La pantalla de "espera/estado del viaje" que pide el criterio de aceptación se implementó como una vista dentro de la misma `RideEstimateScreen` en vez de una pantalla nueva, ya que necesita el mismo origen/destino/token ya cargados y el propio docstring de la pantalla (issue #13) ya anticipaba esta continuación. Solo muestra el estado inicial (`requested`) tras crear el viaje — el seguimiento en tiempo real vía WebSocket es la historia #20, explícitamente fuera de alcance acá.
- "No se le ofrece la opción de solicitar uno nuevo" (criterio de aceptación #2) se resuelve ocultando el flujo de estimar/solicitar mientras haya un viaje recién solicitado en el estado local de la pantalla. No hay persistencia entre reinicios de la app (no existe hoy un endpoint para consultar "¿tengo un viaje activo?" fuera de `GET /rides/{id}` con un id conocido) — el backend igual lo garantiza de forma autoritativa devolviendo 422 en `POST /rides` si el pasajero ya tiene uno activo, que la UI maneja como error de validación.