### PR TITLE
feat(#15): cancelar solicitud de viaje antes de ser aceptada

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -6,8 +6,8 @@
 
 use crate::models::{
     ApiErrorBody, AuthToken, AuthenticatedUser, Coordinates, DataEnvelope, LoginPayload,
-    RegisterPassengerPayload, Ride, RideEstimate, RideEstimateRequestPayload, RideRequestPayload,
-    UpdateProfilePayload, User,
+    RegisterPassengerPayload, Ride, RideCancellation, RideEstimate, RideEstimateRequestPayload,
+    RideRequestPayload, UpdateProfilePayload, User,
 };
 
 #[derive(Debug, Clone)]
@@ -384,6 +384,53 @@ impl std::fmt::Display for RequestRideError {
 
 impl std::error::Error for RequestRideError {}
 
+/// Fallos posibles de `POST /api/v1/rides/{ride}/cancel` (issue #15).
+///
+/// El mismo endpoint sirve tanto para que el pasajero cancele (historias
+/// #16/#22) como para que el conductor asignado libere el viaje (historia
+/// #23) — el cliente no distingue esos dos casos, los resuelve el backend
+/// segun quien llama (ver `openapi.yaml`). `Validation` cubre que el viaje ya
+/// no este en un estado cancelable (`in_progress`, `completed` o ya
+/// `cancelled`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum CancelRideError {
+    /// El viaje no le pertenece al pasajero autenticado ni esta asignado al
+    /// conductor autenticado.
+    Forbidden,
+    /// No existe ningun viaje con ese id.
+    NotFound,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for CancelRideError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CancelRideError::Forbidden => {
+                write!(f, "Este viaje no te pertenece.")
+            }
+            CancelRideError::NotFound => write!(f, "El viaje ya no existe."),
+            CancelRideError::Validation(body) => write!(f, "{}", body.message),
+            CancelRideError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            CancelRideError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            CancelRideError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CancelRideError {}
+
 enum GetOutcome<T> {
     Success(T),
     Unauthorized,
@@ -405,6 +452,14 @@ enum PostRideOutcome<T> {
     Success(T),
     Unauthorized,
     Forbidden,
+    Validation(ApiErrorBody),
+}
+
+enum CancelRideOutcome {
+    Success(RideCancellation),
+    Unauthorized,
+    Forbidden,
+    NotFound,
     Validation(ApiErrorBody),
 }
 
@@ -957,6 +1012,92 @@ impl ApiClient {
                 Ok(PostRideOutcome::Validation(body))
             }
             other => Err(RequestRideError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/rides/{ride}/cancel` — issue #15. No manda body: todo lo
+    /// que decide esta operacion es el id del viaje y quien la pide. Reintenta
+    /// una vez con refresh de token ante un 401, igual que `request_ride`; un
+    /// 403 (viaje ajeno), 404 (no existe) o 422 (estado no cancelable) nunca
+    /// se reintentan.
+    pub async fn cancel_ride(
+        &self,
+        token: &AuthToken,
+        ride_id: u64,
+    ) -> Result<AuthenticatedFetch<RideCancellation>, CancelRideError> {
+        match self
+            .post_cancel_with_token(ride_id, &token.access_token)
+            .await?
+        {
+            CancelRideOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            CancelRideOutcome::Forbidden => return Err(CancelRideError::Forbidden),
+            CancelRideOutcome::NotFound => return Err(CancelRideError::NotFound),
+            CancelRideOutcome::Validation(body) => return Err(CancelRideError::Validation(body)),
+            CancelRideOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| CancelRideError::SessionExpired)?;
+
+        match self
+            .post_cancel_with_token(ride_id, &renewed.access_token)
+            .await?
+        {
+            CancelRideOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            CancelRideOutcome::Forbidden => Err(CancelRideError::Forbidden),
+            CancelRideOutcome::NotFound => Err(CancelRideError::NotFound),
+            CancelRideOutcome::Validation(body) => Err(CancelRideError::Validation(body)),
+            CancelRideOutcome::Unauthorized => Err(CancelRideError::SessionExpired),
+        }
+    }
+
+    async fn post_cancel_with_token(
+        &self,
+        ride_id: u64,
+        access_token: &str,
+    ) -> Result<CancelRideOutcome, CancelRideError> {
+        let url = format!("{}/api/v1/rides/{}/cancel", self.base_url, ride_id);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|err| CancelRideError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<RideCancellation> = response
+                .json()
+                .await
+                .map_err(|err| CancelRideError::Network(err.to_string()))?;
+            return Ok(CancelRideOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(CancelRideOutcome::Unauthorized),
+            403 => Ok(CancelRideOutcome::Forbidden),
+            404 => Ok(CancelRideOutcome::NotFound),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| CancelRideError::Network(err.to_string()))?;
+                Ok(CancelRideOutcome::Validation(body))
+            }
+            other => Err(CancelRideError::Unexpected(other)),
         }
     }
 }
@@ -2173,5 +2314,189 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, RequestRideError::Network(_)));
+    }
+
+    fn sample_cancelled_ride_json() -> serde_json::Value {
+        let mut ride = sample_ride_json();
+        ride["status"] = serde_json::json!("cancelled");
+        ride["cancellation_fee_applies"] = serde_json::json!(false);
+        ride
+    }
+
+    #[tokio::test]
+    async fn cancel_ride_returns_the_cancelled_ride_without_a_fee_when_no_driver_was_assigned() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/cancel"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": sample_cancelled_ride_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.cancel_ride(&sample_token(), 1).await.unwrap();
+
+        assert_eq!(fetch.data.ride.id, 1);
+        assert_eq!(fetch.data.ride.status, crate::models::RideStatus::Cancelled);
+        assert_eq!(fetch.data.cancellation_fee_applies, Some(false));
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn cancel_ride_returns_forbidden_on_403_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/cancel"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.cancel_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(error, CancelRideError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn cancel_ride_returns_not_found_on_404_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/999/cancel"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "No query results for model [App\\Models\\Ride] 999.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.cancel_ride(&sample_token(), 999).await.unwrap_err();
+
+        assert_eq!(error, CancelRideError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn cancel_ride_returns_validation_error_on_422_when_the_ride_is_not_cancellable() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/cancel"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "El viaje está en curso; no se puede cancelar de esta forma.",
+                "errors": {
+                    "ride": ["El viaje está en curso; no se puede cancelar de esta forma."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.cancel_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(
+            error,
+            CancelRideError::Validation(ApiErrorBody {
+                message: "El viaje está en curso; no se puede cancelar de esta forma.".to_string(),
+                errors: Some(HashMap::from([(
+                    "ride".to_string(),
+                    vec!["El viaje está en curso; no se puede cancelar de esta forma.".to_string()]
+                )])),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_ride_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/cancel"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/cancel"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": sample_cancelled_ride_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.cancel_ride(&sample_token(), 1).await.unwrap();
+
+        assert_eq!(fetch.data.ride.id, 1);
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn cancel_ride_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/cancel"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.cancel_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(error, CancelRideError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn cancel_ride_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client.cancel_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert!(matches!(error, CancelRideError::Network(_)));
     }
 }

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -195,6 +195,20 @@ pub struct Ride {
     pub payment: Option<Payment>,
 }
 
+/// `openapi.yaml#/components/schemas/Ride` + `cancellation_fee_applies` —
+/// respuesta de `POST /api/v1/rides/{ride}/cancel` (issue #15).
+///
+/// `cancellation_fee_applies` esta ausente cuando quien cancela es el
+/// conductor asignado (historia #23, fuera de alcance de #15): ese caso no
+/// cancela el viaje, solo lo devuelve al pool sin conductor. `#[serde(flatten)]`
+/// reutiliza `Ride` en vez de repetir sus campos.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct RideCancellation {
+    #[serde(flatten)]
+    pub ride: Ride,
+    pub cancellation_fee_applies: Option<bool>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -392,5 +406,58 @@ mod tests {
                 status: PaymentStatus::Paid,
             })
         );
+    }
+
+    #[test]
+    fn deserializes_ride_cancellation_envelope_with_the_fee_flag() {
+        let json = r#"{
+            "data": {
+                "id": 1,
+                "status": "cancelled",
+                "origin": {"latitude": 4.710989, "longitude": -74.072092},
+                "destination": {"latitude": 4.698, "longitude": -74.061},
+                "distance_meters": 7421,
+                "duration_seconds": 842,
+                "currency": "COP",
+                "estimated_fare": 8850,
+                "driver": null,
+                "requested_at": "2026-07-31T14:03:21+00:00",
+                "started_at": null,
+                "completed_at": null,
+                "final_fare": null,
+                "payment": null,
+                "cancellation_fee_applies": false
+            }
+        }"#;
+
+        let envelope: DataEnvelope<RideCancellation> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(envelope.data.ride.status, RideStatus::Cancelled);
+        assert_eq!(envelope.data.cancellation_fee_applies, Some(false));
+    }
+
+    #[test]
+    fn deserializes_ride_cancellation_without_the_fee_flag_when_the_driver_cancels() {
+        let json = r#"{
+            "id": 1,
+            "status": "requested",
+            "origin": {"latitude": 4.710989, "longitude": -74.072092},
+            "destination": {"latitude": 4.698, "longitude": -74.061},
+            "distance_meters": 7421,
+            "duration_seconds": 842,
+            "currency": "COP",
+            "estimated_fare": 8850,
+            "driver": null,
+            "requested_at": "2026-07-31T14:03:21+00:00",
+            "started_at": null,
+            "completed_at": null,
+            "final_fare": null,
+            "payment": null
+        }"#;
+
+        let cancellation: RideCancellation = serde_json::from_str(json).unwrap();
+
+        assert_eq!(cancellation.ride.status, RideStatus::Requested);
+        assert_eq!(cancellation.cancellation_fee_applies, None);
     }
 }

--- a/crates/moto_ui/src/screens/ride_estimate.rs
+++ b/crates/moto_ui/src/screens/ride_estimate.rs
@@ -13,11 +13,19 @@
 //! Origen y destino se eligen tocando el mapa (`MapView::on_click`, ver
 //! `moto_ui/src/map.rs`), no con campos de texto: la historia depende
 //! explicitamente del componente de mapa (issue #4).
+//!
+//! Mientras el viaje solicitado sigue en `requested` (nadie lo acepto
+//! todavia), el pasajero puede desistir con `POST /api/v1/rides/{ride}/cancel`
+//! (`ApiClient::cancel_ride`, issue #15), lo que devuelve la pantalla al
+//! estado inicial para poder solicitar otro viaje. Una vez que el viaje pasa
+//! a `accepted` este boton deja de ofrecerse — cancelar un viaje ya aceptado
+//! es la historia "Cancelar un viaje aceptado (pasajero)" (#21), fuera de
+//! alcance aca.
 
 use std::sync::Arc;
 
 use dioxus::prelude::*;
-use moto_core::api::{ApiClient, EstimateRideError, RequestRideError};
+use moto_core::api::{ApiClient, CancelRideError, EstimateRideError, RequestRideError};
 use moto_core::models::{Coordinates, Ride, RideEstimate, RideStatus};
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
@@ -51,6 +59,8 @@ pub fn RideEstimateScreen() -> Element {
     let mut ride_error = use_signal(|| None::<RequestRideError>);
     let mut requested_ride = use_signal(|| None::<Ride>);
     let mut is_requesting = use_signal(|| false);
+    let mut cancel_error = use_signal(|| None::<CancelRideError>);
+    let mut is_cancelling = use_signal(|| false);
 
     let on_map_click = move |(lat, lng): (f64, f64)| {
         estimate.set(None);
@@ -119,51 +129,94 @@ pub fn RideEstimateScreen() -> Element {
         }
     };
 
-    let on_request_click = move |_| {
+    let on_request_click = {
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+        move |_| {
+            let Some(token) = session.token() else {
+                return;
+            };
+            let Some((origin_lat, origin_lng)) = origin() else {
+                return;
+            };
+            let Some((destination_lat, destination_lng)) = destination() else {
+                return;
+            };
+            let api_client = api_client.clone();
+            let storage = storage.clone();
+
+            spawn(async move {
+                is_requesting.set(true);
+                ride_error.set(None);
+
+                let origin_coords = Coordinates {
+                    latitude: origin_lat,
+                    longitude: origin_lng,
+                };
+                let destination_coords = Coordinates {
+                    latitude: destination_lat,
+                    longitude: destination_lng,
+                };
+
+                match api_client
+                    .request_ride(&token, origin_coords, destination_coords)
+                    .await
+                {
+                    Ok(fetch) => {
+                        if let Some(refreshed) = fetch.refreshed_token {
+                            session.update_token(refreshed, storage.as_ref());
+                        }
+                        requested_ride.set(Some(fetch.data));
+                    }
+                    Err(RequestRideError::SessionExpired) => {
+                        session.logout(storage.as_ref());
+                    }
+                    Err(err) => {
+                        ride_error.set(Some(err));
+                    }
+                }
+
+                is_requesting.set(false);
+            });
+        }
+    };
+
+    let on_cancel_click = move |_| {
         let Some(token) = session.token() else {
             return;
         };
-        let Some((origin_lat, origin_lng)) = origin() else {
-            return;
-        };
-        let Some((destination_lat, destination_lng)) = destination() else {
+        let Some(ride) = requested_ride() else {
             return;
         };
         let api_client = api_client.clone();
         let storage = storage.clone();
 
         spawn(async move {
-            is_requesting.set(true);
-            ride_error.set(None);
+            is_cancelling.set(true);
+            cancel_error.set(None);
 
-            let origin_coords = Coordinates {
-                latitude: origin_lat,
-                longitude: origin_lng,
-            };
-            let destination_coords = Coordinates {
-                latitude: destination_lat,
-                longitude: destination_lng,
-            };
-
-            match api_client
-                .request_ride(&token, origin_coords, destination_coords)
-                .await
-            {
+            match api_client.cancel_ride(&token, ride.id).await {
                 Ok(fetch) => {
                     if let Some(refreshed) = fetch.refreshed_token {
                         session.update_token(refreshed, storage.as_ref());
                     }
-                    requested_ride.set(Some(fetch.data));
+                    requested_ride.set(None);
+                    estimate.set(None);
+                    estimate_error.set(None);
+                    ride_error.set(None);
+                    origin.set(None);
+                    destination.set(None);
+                    pick_target.set(PickTarget::Origin);
                 }
-                Err(RequestRideError::SessionExpired) => {
+                Err(CancelRideError::SessionExpired) => {
                     session.logout(storage.as_ref());
                 }
                 Err(err) => {
-                    ride_error.set(Some(err));
+                    cancel_error.set(Some(err));
                 }
             }
 
-            is_requesting.set(false);
+            is_cancelling.set(false);
         });
     };
 
@@ -202,6 +255,22 @@ pub fn RideEstimateScreen() -> Element {
                     dd { "{ride.duration_seconds / 60} min" }
                     dt { "Tarifa estimada" }
                     dd { "{ride.currency} {ride.estimated_fare}" }
+                }
+                if ride.status == RideStatus::Requested {
+                    button {
+                        r#type: "button",
+                        class: "ride-cancel-button",
+                        disabled: is_cancelling(),
+                        onclick: on_cancel_click,
+                        if is_cancelling() {
+                            "Cancelando..."
+                        } else {
+                            "Cancelar solicitud"
+                        }
+                    }
+                    if let Some(err) = cancel_error() {
+                        p { class: "ride-cancel-error", role: "alert", "{err}" }
+                    }
                 }
             }
         };


### PR DESCRIPTION
Closes #15

## Qué hace

- `ApiClient::cancel_ride` en `crates/moto_core/src/api.rs`: `POST /api/v1/rides/{ride}/cancel` sin body, reintenta una vez con refresh de token ante un 401 (mismo patrón que `request_ride`/`estimate_ride`), y distingue `403` (Forbidden), `404` (NotFound) y `422` (Validation) sin reintentar en ninguno de esos casos.
- `RideCancellation` en `crates/moto_core/src/models.rs`: reutiliza `Ride` vía `#[serde(flatten)]` y agrega `cancellation_fee_applies: Option<bool>` — presente (`true`/`false`) cuando cancela el pasajero, ausente cuando cancela el conductor asignado (historia #23, fuera de alcance).
- `RideEstimateScreen` (`crates/moto_ui/src/screens/ride_estimate.rs`): mientras el viaje solicitado sigue en `requested`, se ofrece el botón "Cancelar solicitud". Al tener éxito, limpia todo el estado del flujo (viaje, estimación, origen/destino) y vuelve a la pantalla inicial para poder solicitar otro viaje, según pide el criterio de aceptación. El botón deja de mostrarse en cuanto el viaje pasa a `accepted` — cancelar un viaje ya aceptado es la historia "Cancelar un viaje aceptado (pasajero)" (#21), bloqueada todavía por #17 y fuera de alcance aquí.

## Cómo se probó

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace` (69 tests en `moto_core`, incluyendo 7 nuevos para `cancel_ride` cubriendo éxito sin cargo, 403, 404, 422, refresh-y-reintento en 401, sesión expirada, y error de red; 2 nuevos en `models` para la deserialización de `RideCancellation` con y sin `cancellation_fee_applies`)
- `cargo build --package web --target wasm32-unknown-unknown` (mismo comando que usa el CI de `build-web`)
- Verificación manual del contrato contra el backend real: revisé `routes/api.php`, `CancelRideController`, `CancelRideRequest` y la sección `/rides/{id}/cancel` de `openapi.yaml` en `Back_App_MotoCarros` antes de implementar — no hubo gap de contrato.

## Decisiones y riesgos

- El endpoint es compartido con las historias #21/#22/#23 (cancelar un viaje ya aceptado, por pasajero o conductor). El cliente API (`cancel_ride`) es genérico y ya soporta esos casos porque así lo documenta `openapi.yaml`, pero la UI de esta pantalla solo ofrece el botón mientras `status == requested`, tal como piden los criterios de aceptación de #15. Las historias #21/#22/#23 seguirán bloqueadas hasta que se implemente su propia pantalla/flujo.
- No se testeó el renderizado real en navegador (no está en el alcance del CI según `.claude/STANDARDS.md`); la lógica cubierta por tests es el cliente API y la deserialización de modelos.