### PR TITLE
feat(#5): cliente de WebSockets (Echo/Reverb) para tiempo real

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,6 +1644,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ewebsock"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "679247b4a005c82218a5f13b713239b0b6d484ec25347a719f5b7066152a748a"
+dependencies = [
+ "document-features",
+ "js-sys",
+ "log",
+ "tungstenite 0.24.0",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "exr"
 version = "1.74.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,7 +2442,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -3194,6 +3209,7 @@ name = "moto_core"
 version = "0.1.0"
 dependencies = [
  "dioxus",
+ "ewebsock",
  "reqwest 0.13.1",
  "serde",
  "serde_json",
@@ -4450,7 +4466,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -4488,7 +4504,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -5635,6 +5651,27 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.7",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
@@ -5996,6 +6033,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/moto_core/Cargo.toml
+++ b/crates/moto_core/Cargo.toml
@@ -8,6 +8,7 @@ dioxus = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
+ewebsock = { version = "0.8", features = ["tls"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -5,9 +5,9 @@
 //! `Back_App_MotoCarros`).
 
 use crate::models::{
-    ApiErrorBody, AuthToken, AuthenticatedUser, Coordinates, DataEnvelope, LoginPayload,
-    RegisterPassengerPayload, Ride, RideCancellation, RideEstimate, RideEstimateRequestPayload,
-    RideRequestPayload, UpdateProfilePayload, User,
+    ApiErrorBody, AuthToken, AuthenticatedUser, BroadcastAuthPayload, BroadcastAuthResponse,
+    Coordinates, DataEnvelope, LoginPayload, RegisterPassengerPayload, Ride, RideCancellation,
+    RideEstimate, RideEstimateRequestPayload, RideRequestPayload, UpdateProfilePayload, User,
 };
 
 #[derive(Debug, Clone)]
@@ -430,6 +430,46 @@ impl std::fmt::Display for CancelRideError {
 }
 
 impl std::error::Error for CancelRideError {}
+
+/// Fallos posibles de `POST /api/v1/broadcasting/auth` (issue #5).
+///
+/// A diferencia del resto de las requests autenticadas, esta nunca reintenta
+/// con un refresh de token: el endpoint exige explicitamente un access token
+/// vigente (ver `openapi.yaml`), asi que un 401 aca es directamente un fallo
+/// de autenticacion, no una senal de "token vencido, renovar y reintentar".
+#[derive(Debug, Clone, PartialEq)]
+pub enum BroadcastAuthError {
+    Unauthorized,
+    /// El usuario autenticado no participa de la entidad del canal (no es el
+    /// conductor de `driver.{id}`, o no participa del viaje de `ride.{id}`).
+    Forbidden,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for BroadcastAuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BroadcastAuthError::Unauthorized => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            BroadcastAuthError::Forbidden => {
+                write!(f, "No tienes permiso para suscribirte a este canal.")
+            }
+            BroadcastAuthError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            BroadcastAuthError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BroadcastAuthError {}
 
 enum GetOutcome<T> {
     Success(T),
@@ -1098,6 +1138,48 @@ impl ApiClient {
                 Ok(CancelRideOutcome::Validation(body))
             }
             other => Err(CancelRideError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/broadcasting/auth` — issue #5. Firma la suscripcion de
+    /// `channel_name` (ya con el prefijo `private-` que espera el protocolo
+    /// Pusher, ver `crate::realtime`) para el `socket_id` que asigno Reverb
+    /// al abrir la conexion de WebSocket. No reintenta con refresh de token:
+    /// este endpoint exige un access token vigente (ver `openapi.yaml`).
+    pub async fn authenticate_broadcast_channel(
+        &self,
+        token: &AuthToken,
+        socket_id: &str,
+        channel_name: &str,
+    ) -> Result<BroadcastAuthResponse, BroadcastAuthError> {
+        let url = format!("{}/api/v1/broadcasting/auth", self.base_url);
+        let payload = BroadcastAuthPayload {
+            socket_id: socket_id.to_string(),
+            channel_name: channel_name.to_string(),
+        };
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(&token.access_token)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|err| BroadcastAuthError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            return response
+                .json()
+                .await
+                .map_err(|err| BroadcastAuthError::Network(err.to_string()));
+        }
+
+        match status.as_u16() {
+            401 => Err(BroadcastAuthError::Unauthorized),
+            403 => Err(BroadcastAuthError::Forbidden),
+            other => Err(BroadcastAuthError::Unexpected(other)),
         }
     }
 }
@@ -2498,5 +2580,88 @@ mod tests {
         let error = client.cancel_ride(&sample_token(), 1).await.unwrap_err();
 
         assert!(matches!(error, CancelRideError::Network(_)));
+    }
+
+    #[tokio::test]
+    async fn authenticate_broadcast_channel_returns_the_signature_on_success() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/broadcasting/auth"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .and(body_json(serde_json::json!({
+                "socket_id": "123456.789012",
+                "channel_name": "private-ride.7",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "auth": "motoya-local:8f3c1a2b4d5e6f70",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let response = client
+            .authenticate_broadcast_channel(&sample_token(), "123456.789012", "private-ride.7")
+            .await
+            .unwrap();
+
+        assert_eq!(response.auth, "motoya-local:8f3c1a2b4d5e6f70");
+    }
+
+    #[tokio::test]
+    async fn authenticate_broadcast_channel_returns_unauthorized_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/broadcasting/auth"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .authenticate_broadcast_channel(&sample_token(), "123456.789012", "private-ride.7")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, BroadcastAuthError::Unauthorized);
+    }
+
+    #[tokio::test]
+    async fn authenticate_broadcast_channel_returns_forbidden_on_403() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/broadcasting/auth"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .authenticate_broadcast_channel(&sample_token(), "123456.789012", "private-ride.7")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, BroadcastAuthError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn authenticate_broadcast_channel_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .authenticate_broadcast_channel(&sample_token(), "123456.789012", "private-ride.7")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, BroadcastAuthError::Network(_)));
     }
 }

--- a/crates/moto_core/src/lib.rs
+++ b/crates/moto_core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
 pub mod models;
+pub mod realtime;
 pub mod state;
 pub mod storage;

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -209,6 +209,26 @@ pub struct RideCancellation {
     pub cancellation_fee_applies: Option<bool>,
 }
 
+/// Body de `POST /api/v1/broadcasting/auth`
+/// (`openapi.yaml#/components/schemas/BroadcastAuthRequest`).
+///
+/// Los nombres de los campos los fija el protocolo Pusher que habla Reverb,
+/// no esta API (issue #5).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct BroadcastAuthPayload {
+    pub socket_id: String,
+    pub channel_name: String,
+}
+
+/// `openapi.yaml#/components/schemas/BroadcastAuthResponse` — respuesta de
+/// `POST /api/v1/broadcasting/auth` (issue #5). Sin el envelope `data` del
+/// resto de la API: el formato lo fija el protocolo Pusher, que lo espera
+/// asi para reenviarlo tal cual a Reverb.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct BroadcastAuthResponse {
+    pub auth: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -459,5 +479,32 @@ mod tests {
 
         assert_eq!(cancellation.ride.status, RideStatus::Requested);
         assert_eq!(cancellation.cancellation_fee_applies, None);
+    }
+
+    #[test]
+    fn broadcast_auth_payload_serializes_socket_id_and_channel_name() {
+        let payload = BroadcastAuthPayload {
+            socket_id: "123456.789012".to_string(),
+            channel_name: "private-ride.7".to_string(),
+        };
+
+        let json = serde_json::to_value(&payload).unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "socket_id": "123456.789012",
+                "channel_name": "private-ride.7",
+            })
+        );
+    }
+
+    #[test]
+    fn deserializes_broadcast_auth_response() {
+        let json = r#"{"auth": "motoya-local:8f3c1a2b4d5e6f70"}"#;
+
+        let response: BroadcastAuthResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(response.auth, "motoya-local:8f3c1a2b4d5e6f70");
     }
 }

--- a/crates/moto_core/src/realtime.rs
+++ b/crates/moto_core/src/realtime.rs
@@ -1,0 +1,523 @@
+//! Cliente de WebSockets hacia el servidor Reverb de `Back_App_MotoCarros`
+//! (issue #5), base para las historias de tracking en tiempo real (estado
+//! del viaje, ubicacion del conductor).
+//!
+//! Habla el protocolo Pusher que sirve Reverb: tras el handshake
+//! (`pusher:connection_established`), cada canal privado (`private-ride.7`,
+//! `private-driver.3`, ver `routes/channels.php` de `Back_App_MotoCarros`)
+//! se suscribe firmando `socket_id` + `channel_name` contra
+//! `POST /api/v1/broadcasting/auth` (`ApiClient::authenticate_broadcast_channel`)
+//! y mandando esa firma en un frame `pusher:subscribe`.
+//!
+//! El transporte real (`ewebsock`, que soporta nativo y `wasm32-unknown-unknown`
+//! con la misma API) esta detras del trait privado `WsTransport` para poder
+//! testear la maquina de estados con un doble de prueba, sin abrir un socket
+//! real.
+
+use serde::Deserialize;
+
+use crate::api::{ApiClient, BroadcastAuthError};
+use crate::models::AuthToken;
+
+/// Prefijo que exige el protocolo Pusher para cualquier canal privado (ver
+/// `routes/channels.php` de `Back_App_MotoCarros`: "El cliente los pide con
+/// el prefijo `private-`").
+const PRIVATE_CHANNEL_PREFIX: &str = "private-";
+
+trait WsTransport {
+    fn send_text(&mut self, text: String);
+    fn try_recv(&mut self) -> Option<ewebsock::WsEvent>;
+    fn close(&mut self);
+}
+
+struct EwebsockTransport {
+    sender: ewebsock::WsSender,
+    receiver: ewebsock::WsReceiver,
+}
+
+impl WsTransport for EwebsockTransport {
+    fn send_text(&mut self, text: String) {
+        self.sender.send(ewebsock::WsMessage::Text(text));
+    }
+
+    fn try_recv(&mut self) -> Option<ewebsock::WsEvent> {
+        self.receiver.try_recv()
+    }
+
+    fn close(&mut self) {
+        self.sender.close();
+    }
+}
+
+/// Estado de la conexion de WebSocket con Reverb.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConnectionState {
+    /// Se abrio la conexion, todavia no llego `pusher:connection_established`.
+    Connecting,
+    /// Handshake completo: `socket_id()` ya tiene un valor y se puede
+    /// suscribir a canales.
+    Connected,
+    /// El socket se cerro o fallo. `attempt` cuenta cuantas veces seguidas
+    /// paso esto sin volver a `Connected` en el medio.
+    Reconnecting { attempt: u32 },
+}
+
+/// Un evento de canal ya desenvuelto del frame de Pusher (`data` viaja
+/// stringificado en el protocolo; aca ya se extrajo del frame exterior,
+/// pero sigue siendo el JSON crudo que public el backend — el caller lo
+/// deserializa al tipo que le corresponda segun `channel`/`event`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChannelEvent {
+    /// Nombre completo del canal, con el prefijo `private-` incluido.
+    pub channel: String,
+    pub event: String,
+    /// JSON crudo (como string) que publico el backend, o vacio si el frame
+    /// no traia `data` (p.ej. `pusher_internal:subscription_succeeded`).
+    pub data: String,
+}
+
+/// Fallos posibles de `RealtimeClient::subscribe`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SubscribeError {
+    /// Todavia no llego el handshake (`pusher:connection_established`), asi
+    /// que no hay `socket_id` con el que firmar la suscripcion.
+    NotConnected,
+    Auth(BroadcastAuthError),
+}
+
+impl std::fmt::Display for SubscribeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SubscribeError::NotConnected => {
+                write!(f, "Todavia no se establecio la conexion en tiempo real.")
+            }
+            SubscribeError::Auth(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for SubscribeError {}
+
+#[derive(Debug, Deserialize)]
+struct PusherFrame {
+    event: String,
+    #[serde(default)]
+    channel: Option<String>,
+    #[serde(default)]
+    data: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConnectionEstablishedData {
+    socket_id: String,
+}
+
+/// Cliente de tiempo real: mantiene una conexion de WebSocket con Reverb y
+/// expone una forma de suscribirse a canales privados y recibir sus eventos.
+///
+/// No hace reconexion automatica con backoff: el crate no tiene runtime
+/// propio ni una forma cross-platform de dormir un timer (ver
+/// `.claude/STANDARDS.md`, separacion de codigo especifico de plataforma).
+/// Cuando la conexion se cae, el caller debe llamar `reconnect()` y volver a
+/// suscribirse a `pending_subscriptions()` una vez que `state()` vuelva a
+/// `Connected`.
+pub struct RealtimeClient {
+    api: ApiClient,
+    ws_url: String,
+    transport: Box<dyn WsTransport>,
+    state: ConnectionState,
+    socket_id: Option<String>,
+    subscriptions: Vec<String>,
+}
+
+impl RealtimeClient {
+    /// Abre la conexion de WebSocket hacia `ws_url` (p.ej. `wss://host/app/{key}`,
+    /// ver configuracion de Reverb en `Back_App_MotoCarros`).
+    pub fn connect(api: ApiClient, ws_url: impl Into<String>) -> Result<Self, String> {
+        let ws_url = ws_url.into();
+        let (sender, receiver) = ewebsock::connect(ws_url.clone(), ewebsock::Options::default())?;
+        Ok(Self::with_transport(
+            api,
+            ws_url,
+            Box::new(EwebsockTransport { sender, receiver }),
+        ))
+    }
+
+    fn with_transport(api: ApiClient, ws_url: String, transport: Box<dyn WsTransport>) -> Self {
+        Self {
+            api,
+            ws_url,
+            transport,
+            state: ConnectionState::Connecting,
+            socket_id: None,
+            subscriptions: Vec::new(),
+        }
+    }
+
+    pub fn state(&self) -> ConnectionState {
+        self.state.clone()
+    }
+
+    pub fn socket_id(&self) -> Option<&str> {
+        self.socket_id.as_deref()
+    }
+
+    /// Canales a los que se pidio suscripcion, para volver a suscribirse
+    /// tras un `reconnect()`.
+    pub fn pending_subscriptions(&self) -> &[String] {
+        &self.subscriptions
+    }
+
+    /// Suscribe a `channel` (p.ej. `"ride.7"`, sin el prefijo `private-`: lo
+    /// agrega este metodo, ver `routes/channels.php` de
+    /// `Back_App_MotoCarros`). Firma la suscripcion contra
+    /// `POST /api/v1/broadcasting/auth` y manda el frame `pusher:subscribe`.
+    pub async fn subscribe(
+        &mut self,
+        token: &AuthToken,
+        channel: &str,
+    ) -> Result<(), SubscribeError> {
+        let socket_id = self.socket_id.clone().ok_or(SubscribeError::NotConnected)?;
+        let channel_name = format!("{PRIVATE_CHANNEL_PREFIX}{channel}");
+
+        let auth = self
+            .api
+            .authenticate_broadcast_channel(token, &socket_id, &channel_name)
+            .await
+            .map_err(SubscribeError::Auth)?;
+
+        let frame = serde_json::json!({
+            "event": "pusher:subscribe",
+            "data": {
+                "channel": channel_name,
+                "auth": auth.auth,
+            },
+        });
+        self.transport.send_text(frame.to_string());
+
+        if !self.subscriptions.contains(&channel_name) {
+            self.subscriptions.push(channel_name);
+        }
+
+        Ok(())
+    }
+
+    /// Cierra la conexion actual y abre una nueva hacia la misma URL.
+    /// No vuelve a suscribirse a nada: el caller debe hacerlo con
+    /// `pending_subscriptions()` una vez que `state()` sea `Connected`.
+    pub fn reconnect(&mut self) -> Result<(), String> {
+        self.transport.close();
+        let (sender, receiver) =
+            ewebsock::connect(self.ws_url.clone(), ewebsock::Options::default())?;
+        self.transport = Box::new(EwebsockTransport { sender, receiver });
+        self.socket_id = None;
+        self.state = ConnectionState::Connecting;
+        Ok(())
+    }
+
+    /// Drena los eventos pendientes del transporte, actualiza el estado
+    /// interno (handshake, desconexion) y devuelve los eventos de canal
+    /// listos para consumir. Pensado para llamarse desde el loop de
+    /// renderizado de la pantalla que este escuchando (ver historias de
+    /// tracking en tiempo real, issue #19/#20).
+    pub fn poll_events(&mut self) -> Vec<ChannelEvent> {
+        let mut events = Vec::new();
+
+        while let Some(event) = self.transport.try_recv() {
+            match event {
+                ewebsock::WsEvent::Opened => {
+                    self.state = ConnectionState::Connecting;
+                }
+                ewebsock::WsEvent::Closed | ewebsock::WsEvent::Error(_) => {
+                    let attempt = match self.state {
+                        ConnectionState::Reconnecting { attempt } => attempt + 1,
+                        _ => 1,
+                    };
+                    self.state = ConnectionState::Reconnecting { attempt };
+                    self.socket_id = None;
+                }
+                ewebsock::WsEvent::Message(ewebsock::WsMessage::Text(text)) => {
+                    if let Some(channel_event) = self.handle_frame(&text) {
+                        events.push(channel_event);
+                    }
+                }
+                ewebsock::WsEvent::Message(_) => {}
+            }
+        }
+
+        events
+    }
+
+    /// Frame malformado (JSON invalido) se ignora sin panic: no hay forma de
+    /// distinguir un frame corrupto de una version futura del protocolo que
+    /// este cliente todavia no entiende, y ninguno de los dos casos deberia
+    /// tumbar la conexion.
+    fn handle_frame(&mut self, text: &str) -> Option<ChannelEvent> {
+        let frame: PusherFrame = serde_json::from_str(text).ok()?;
+
+        if frame.event == "pusher:connection_established" {
+            if let Some(data) = &frame.data
+                && let Ok(established) = serde_json::from_str::<ConnectionEstablishedData>(data)
+            {
+                self.socket_id = Some(established.socket_id);
+                self.state = ConnectionState::Connected;
+            }
+            return None;
+        }
+
+        let channel = frame.channel?;
+        Some(ChannelEvent {
+            channel,
+            event: frame.event,
+            data: frame.data.unwrap_or_default(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, VecDeque};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    struct FakeTransport {
+        incoming: VecDeque<ewebsock::WsEvent>,
+        sent: Vec<String>,
+        closed: bool,
+    }
+
+    impl FakeTransport {
+        fn new(incoming: Vec<ewebsock::WsEvent>) -> Self {
+            Self {
+                incoming: incoming.into(),
+                sent: Vec::new(),
+                closed: false,
+            }
+        }
+    }
+
+    impl WsTransport for FakeTransport {
+        fn send_text(&mut self, text: String) {
+            self.sent.push(text);
+        }
+
+        fn try_recv(&mut self) -> Option<ewebsock::WsEvent> {
+            self.incoming.pop_front()
+        }
+
+        fn close(&mut self) {
+            self.closed = true;
+        }
+    }
+
+    fn connection_established_frame(socket_id: &str) -> ewebsock::WsEvent {
+        let data = serde_json::json!({ "socket_id": socket_id, "activity_timeout": 30 });
+        let frame = serde_json::json!({
+            "event": "pusher:connection_established",
+            "data": data.to_string(),
+        });
+        ewebsock::WsEvent::Message(ewebsock::WsMessage::Text(frame.to_string()))
+    }
+
+    fn sample_token() -> AuthToken {
+        AuthToken {
+            access_token: "jwt-token".to_string(),
+            token_type: "bearer".to_string(),
+            expires_in: Some(900),
+        }
+    }
+
+    fn client_with_events(events: Vec<ewebsock::WsEvent>) -> RealtimeClient {
+        RealtimeClient::with_transport(
+            ApiClient::new("https://unreachable.invalid"),
+            "wss://unreachable.invalid/app/key".to_string(),
+            Box::new(FakeTransport::new(events)),
+        )
+    }
+
+    #[test]
+    fn starts_connecting_without_a_socket_id() {
+        let client = client_with_events(vec![]);
+
+        assert_eq!(client.state(), ConnectionState::Connecting);
+        assert_eq!(client.socket_id(), None);
+    }
+
+    #[test]
+    fn poll_events_extracts_the_socket_id_from_the_handshake() {
+        let mut client = client_with_events(vec![connection_established_frame("123456.789012")]);
+
+        let events = client.poll_events();
+
+        assert!(events.is_empty());
+        assert_eq!(client.state(), ConnectionState::Connected);
+        assert_eq!(client.socket_id(), Some("123456.789012"));
+    }
+
+    #[test]
+    fn poll_events_ignores_a_malformed_frame_without_panicking() {
+        let mut client = client_with_events(vec![ewebsock::WsEvent::Message(
+            ewebsock::WsMessage::Text("not json at all".to_string()),
+        )]);
+
+        let events = client.poll_events();
+
+        assert!(events.is_empty());
+        assert_eq!(client.state(), ConnectionState::Connecting);
+    }
+
+    #[test]
+    fn poll_events_surfaces_subscription_succeeded_as_a_channel_event() {
+        let frame = serde_json::json!({
+            "event": "pusher_internal:subscription_succeeded",
+            "channel": "private-ride.7",
+        });
+        let mut client = client_with_events(vec![
+            connection_established_frame("123456.789012"),
+            ewebsock::WsEvent::Message(ewebsock::WsMessage::Text(frame.to_string())),
+        ]);
+
+        let events = client.poll_events();
+
+        assert_eq!(
+            events,
+            vec![ChannelEvent {
+                channel: "private-ride.7".to_string(),
+                event: "pusher_internal:subscription_succeeded".to_string(),
+                data: String::new(),
+            }]
+        );
+    }
+
+    #[test]
+    fn poll_events_decodes_the_stringified_data_of_a_custom_channel_event() {
+        let inner_data = serde_json::json!({ "status": "in_progress" });
+        let frame = serde_json::json!({
+            "event": "RideStatusChanged",
+            "channel": "private-ride.7",
+            "data": inner_data.to_string(),
+        });
+        let mut client = client_with_events(vec![ewebsock::WsEvent::Message(
+            ewebsock::WsMessage::Text(frame.to_string()),
+        )]);
+
+        let events = client.poll_events();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].channel, "private-ride.7");
+        assert_eq!(events[0].event, "RideStatusChanged");
+        let decoded: HashMap<String, String> = serde_json::from_str(&events[0].data).unwrap();
+        assert_eq!(decoded.get("status"), Some(&"in_progress".to_string()));
+    }
+
+    #[test]
+    fn poll_events_moves_to_reconnecting_on_closed_and_clears_the_socket_id() {
+        let mut client = client_with_events(vec![
+            connection_established_frame("123456.789012"),
+            ewebsock::WsEvent::Closed,
+        ]);
+
+        client.poll_events();
+
+        assert_eq!(client.state(), ConnectionState::Reconnecting { attempt: 1 });
+        assert_eq!(client.socket_id(), None);
+    }
+
+    #[test]
+    fn poll_events_increments_the_reconnect_attempt_on_repeated_failures() {
+        let mut client = client_with_events(vec![ewebsock::WsEvent::Error("boom".to_string())]);
+        client.poll_events();
+        assert_eq!(client.state(), ConnectionState::Reconnecting { attempt: 1 });
+
+        client = client_with_events(vec![ewebsock::WsEvent::Closed]);
+        client.state = ConnectionState::Reconnecting { attempt: 1 };
+        client.poll_events();
+
+        assert_eq!(client.state(), ConnectionState::Reconnecting { attempt: 2 });
+    }
+
+    #[tokio::test]
+    async fn subscribe_fails_without_sending_anything_when_not_connected_yet() {
+        let mut client = client_with_events(vec![]);
+
+        let error = client
+            .subscribe(&sample_token(), "ride.7")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, SubscribeError::NotConnected);
+        assert!(client.pending_subscriptions().is_empty());
+    }
+
+    #[tokio::test]
+    async fn subscribe_authenticates_and_sends_the_pusher_subscribe_frame() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/broadcasting/auth"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "auth": "motoya-local:8f3c1a2b4d5e6f70",
+            })))
+            .mount(&server)
+            .await;
+
+        let mut client = RealtimeClient::with_transport(
+            ApiClient::new(server.uri()),
+            "wss://unreachable.invalid/app/key".to_string(),
+            Box::new(FakeTransport::new(vec![connection_established_frame(
+                "123456.789012",
+            )])),
+        );
+        client.poll_events();
+
+        client.subscribe(&sample_token(), "ride.7").await.unwrap();
+
+        assert_eq!(
+            client.pending_subscriptions(),
+            &["private-ride.7".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_returns_forbidden_when_the_backend_rejects_the_channel() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/broadcasting/auth"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let mut client = RealtimeClient::with_transport(
+            ApiClient::new(server.uri()),
+            "wss://unreachable.invalid/app/key".to_string(),
+            Box::new(FakeTransport::new(vec![connection_established_frame(
+                "123456.789012",
+            )])),
+        );
+        client.poll_events();
+
+        let error = client
+            .subscribe(&sample_token(), "driver.3")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, SubscribeError::Auth(BroadcastAuthError::Forbidden));
+        assert!(client.pending_subscriptions().is_empty());
+    }
+
+    #[test]
+    fn reconnect_resets_the_socket_id_and_the_state() {
+        let mut client = client_with_events(vec![connection_established_frame("123456.789012")]);
+        client.poll_events();
+        assert_eq!(client.state(), ConnectionState::Connected);
+
+        client.reconnect().unwrap();
+
+        assert_eq!(client.state(), ConnectionState::Connecting);
+        assert_eq!(client.socket_id(), None);
+    }
+}


### PR DESCRIPTION
Closes #5

## Qué hace

- `ApiClient::authenticate_broadcast_channel` (`crates/moto_core/src/api.rs`): `POST /api/v1/broadcasting/auth` con el JWT vigente para firmar la suscripción a un canal privado. No reintenta con refresh de token — este endpoint exige un access token vigente (ver `openapi.yaml`), así que un 401 es un fallo de autenticación directo, no una señal de "renovar y reintentar" como en el resto del cliente. `BroadcastAuthError` sigue el mismo patrón que `LoginError`/`RefreshError` (Unauthorized/Forbidden/Network/Unexpected).
- `BroadcastAuthPayload` / `BroadcastAuthResponse` en `models.rs`.
- `crates/moto_core/src/realtime.rs` (módulo nuevo): `RealtimeClient`, la máquina de estados del protocolo Pusher/Reverb —
  - handshake (`pusher:connection_established` → captura `socket_id`),
  - `subscribe("ride.42")` (autentica contra `broadcasting/auth` y envía `pusher:subscribe`),
  - `poll_events()` que devuelve `ChannelEvent { channel, event, data }` desenvolviendo el `data` stringificado del protocolo,
  - reconexión explícita (`ConnectionState::Reconnecting { attempt }`, `pending_subscriptions()`, `reconnect()`) — el caller debe volver a llamar `subscribe` tras reconectar; no hay retry automático con backoff porque el crate no tiene runtime propio ni una forma cross-platform de dormir un timer.
- El transporte WS está detrás de un trait privado (`WsTransport`) para poder testear la máquina de estados con un doble de prueba sin abrir un socket real. La implementación real usa `ewebsock 0.8` (agregado a `Cargo.toml` de `moto_core`), que soporta nativo y `wasm32-unknown-unknown` con la misma API, sin `#[cfg(target_arch)]` en este crate.

## Cómo se probó

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings` ✅ (sin warnings)
- `cargo test --workspace --exclude mobile` ✅ (94 tests, incluyendo los nuevos de `api::tests::authenticate_broadcast_channel_*` y `realtime::tests::*`: handshake, subscribe+auth+frame, subscription_succeeded, evento de canal con `data` decodificado, desconexión → reconexión, frame malformado ignorado sin panic)
- `cargo build --package web --target wasm32-unknown-unknown` ✅ (mismo comando que usa `build-web` en `.github/workflows/ci.yml`)

## Decisiones y riesgos

- Fuera de alcance (según el propio issue): qué se hace con cada evento recibido — eso lo definen las historias de tracking en tiempo real que van a consumir este cliente (#19, #20).
- No hay reintento automático con backoff exponencial: se expone el estado `Reconnecting` y queda a criterio del caller (con acceso a un runtime/timer real, según la plataforma) decidir cuándo reintentar `reconnect()`.
- Esta implementación fue escrita en una corrida anterior mientras el issue estaba bloqueado por un crash local de `rustc` ajeno al código (ver historial de comentarios en #5); el crash ya no se reproduce y el diseño quedó validado, así que se retomó el trabajo commiteado localmente sin cambios de diseño.