### PR TITLE
feat(#7): registrarme como conductor

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -6,9 +6,13 @@
 
 use crate::models::{
     ApiErrorBody, AuthToken, AuthenticatedUser, BroadcastAuthPayload, BroadcastAuthResponse,
-    Coordinates, DataEnvelope, LoginPayload, RegisterPassengerPayload, Ride, RideCancellation,
-    RideEstimate, RideEstimateRequestPayload, RideRequestPayload, UpdateProfilePayload, User,
+    Coordinates, DataEnvelope, LoginPayload, RegisterDriverPayload, RegisterPassengerPayload, Ride,
+    RideCancellation, RideEstimate, RideEstimateRequestPayload, RideRequestPayload,
+    UpdateProfilePayload, User,
 };
+
+#[cfg(test)]
+use crate::models::Role;
 
 #[derive(Debug, Clone)]
 pub struct ApiClient {
@@ -52,17 +56,24 @@ impl std::fmt::Display for LoginError {
 
 impl std::error::Error for LoginError {}
 
-/// Fallos posibles de `POST /api/v1/auth/register/passenger`.
+/// Fallos posibles de `POST /api/v1/auth/register/passenger` y de
+/// `POST /api/v1/auth/register/driver` (issue #7) — comparten forma porque
+/// ambos registros validan el mismo tipo de errores, salvo
+/// `InvalidLicenseNumber`, que solo aplica al registro de conductor.
 ///
-/// `InvalidEmail`/`InvalidPhone` se detectan en el cliente antes de mandar la
-/// request (formato basico), sin duplicar las reglas completas del backend
-/// (unicidad, normalizacion) — esas siguen viajando como `Validation` en un
-/// 422 (ver `openapi.yaml` de `Back_App_MotoCarros`).
+/// `InvalidEmail`/`InvalidPhone`/`InvalidLicenseNumber` se detectan en el
+/// cliente antes de mandar la request (formato basico), sin duplicar las
+/// reglas completas del backend (unicidad, normalizacion) — esas siguen
+/// viajando como `Validation` en un 422 (ver `openapi.yaml` de
+/// `Back_App_MotoCarros`).
 #[derive(Debug, Clone, PartialEq)]
 pub enum RegisterError {
     EmptyFields,
     InvalidEmail,
     InvalidPhone,
+    /// `license_number` no cumple el formato que exige el backend
+    /// (`RegisterDriverRequest`, regex `^[A-Z0-9-]{5,50}$`).
+    InvalidLicenseNumber,
     Validation(ApiErrorBody),
     Network(String),
     Unexpected(u16),
@@ -75,6 +86,12 @@ impl std::fmt::Display for RegisterError {
             RegisterError::InvalidEmail => write!(f, "Ingresa un email valido."),
             RegisterError::InvalidPhone => {
                 write!(f, "Ingresa un telefono valido (7 a 15 digitos).")
+            }
+            RegisterError::InvalidLicenseNumber => {
+                write!(
+                    f,
+                    "Ingresa un numero de documento valido (5 a 50 caracteres, solo letras mayusculas, numeros y guiones)."
+                )
             }
             RegisterError::Validation(body) => write!(f, "{}", body.message),
             RegisterError::Network(_) => {
@@ -124,6 +141,16 @@ fn is_valid_email(email: &str) -> bool {
 fn is_valid_phone(phone: &str) -> bool {
     let digits = phone.strip_prefix('+').unwrap_or(phone);
     (7..=15).contains(&digits.len()) && digits.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Mismo regex que `RegisterDriverRequest` en el backend
+/// (`^[A-Z0-9-]{5,50}$`, ver issue #7): 5 a 50 caracteres, solo letras
+/// mayusculas ASCII, digitos y guiones.
+fn is_valid_license_number(license_number: &str) -> bool {
+    (5..=50).contains(&license_number.len())
+        && license_number
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
 }
 
 /// Fallos posibles de `POST /api/v1/auth/refresh`.
@@ -599,6 +626,83 @@ impl ApiClient {
             email: email.to_string(),
             phone: phone.to_string(),
             password: password.to_string(),
+        };
+
+        let response = self
+            .http
+            .post(url)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|err| RegisterError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<AuthenticatedUser> = response
+                .json()
+                .await
+                .map_err(|err| RegisterError::Network(err.to_string()))?;
+            return Ok(envelope.data);
+        }
+
+        match status.as_u16() {
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| RegisterError::Network(err.to_string()))?;
+                Err(RegisterError::Validation(body))
+            }
+            other => Err(RegisterError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/auth/register/driver` — issue #7.
+    ///
+    /// El rol no se manda: lo fija el endpoint. `license_number` es
+    /// obligatorio para el backend (`RegisterDriverRequest`) — sin el,
+    /// siempre responde 422, sin importar el resto del formulario. Si la
+    /// respuesta es exitosa, la cuenta queda con sesion iniciada igual que
+    /// tras un login (mismo shape `AuthenticatedUser`).
+    pub async fn register_driver(
+        &self,
+        name: &str,
+        email: &str,
+        phone: &str,
+        password: &str,
+        license_number: &str,
+    ) -> Result<AuthenticatedUser, RegisterError> {
+        let name = name.trim();
+        let email = email.trim();
+        let phone = phone.trim();
+        let license_number = license_number.trim();
+
+        if name.is_empty()
+            || email.is_empty()
+            || phone.is_empty()
+            || password.is_empty()
+            || license_number.is_empty()
+        {
+            return Err(RegisterError::EmptyFields);
+        }
+        if !is_valid_email(email) {
+            return Err(RegisterError::InvalidEmail);
+        }
+        if !is_valid_phone(phone) {
+            return Err(RegisterError::InvalidPhone);
+        }
+        if !is_valid_license_number(license_number) {
+            return Err(RegisterError::InvalidLicenseNumber);
+        }
+
+        let url = format!("{}/api/v1/auth/register/driver", self.base_url);
+        let payload = RegisterDriverPayload {
+            name: name.to_string(),
+            email: email.to_string(),
+            phone: phone.to_string(),
+            password: password.to_string(),
+            license_number: license_number.to_string(),
         };
 
         let response = self
@@ -1462,6 +1566,258 @@ mod tests {
                 "ana@example.com",
                 "+573001234567",
                 "motoya2026",
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RegisterError::Network(_)));
+    }
+
+    #[tokio::test]
+    async fn register_driver_rejects_empty_fields_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .register_driver(
+                    "",
+                    "carlos@example.com",
+                    "+573001234567",
+                    "motoya2026",
+                    "ABC1234"
+                )
+                .await,
+            Err(RegisterError::EmptyFields)
+        );
+        assert_eq!(
+            client
+                .register_driver("Carlos Perez", "", "+573001234567", "motoya2026", "ABC1234")
+                .await,
+            Err(RegisterError::EmptyFields)
+        );
+        assert_eq!(
+            client
+                .register_driver(
+                    "Carlos Perez",
+                    "carlos@example.com",
+                    "",
+                    "motoya2026",
+                    "ABC1234"
+                )
+                .await,
+            Err(RegisterError::EmptyFields)
+        );
+        assert_eq!(
+            client
+                .register_driver(
+                    "Carlos Perez",
+                    "carlos@example.com",
+                    "+573001234567",
+                    "",
+                    "ABC1234"
+                )
+                .await,
+            Err(RegisterError::EmptyFields)
+        );
+        assert_eq!(
+            client
+                .register_driver(
+                    "Carlos Perez",
+                    "carlos@example.com",
+                    "+573001234567",
+                    "motoya2026",
+                    ""
+                )
+                .await,
+            Err(RegisterError::EmptyFields)
+        );
+    }
+
+    #[tokio::test]
+    async fn register_driver_rejects_invalid_email_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .register_driver(
+                    "Carlos Perez",
+                    "not-an-email",
+                    "+573001234567",
+                    "motoya2026",
+                    "ABC1234"
+                )
+                .await,
+            Err(RegisterError::InvalidEmail)
+        );
+    }
+
+    #[tokio::test]
+    async fn register_driver_rejects_invalid_phone_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .register_driver(
+                    "Carlos Perez",
+                    "carlos@example.com",
+                    "123",
+                    "motoya2026",
+                    "ABC1234"
+                )
+                .await,
+            Err(RegisterError::InvalidPhone)
+        );
+    }
+
+    #[tokio::test]
+    async fn register_driver_rejects_invalid_license_number_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        // Muy corto.
+        assert_eq!(
+            client
+                .register_driver(
+                    "Carlos Perez",
+                    "carlos@example.com",
+                    "+573001234567",
+                    "motoya2026",
+                    "AB1"
+                )
+                .await,
+            Err(RegisterError::InvalidLicenseNumber)
+        );
+        // Minusculas: el backend solo acepta mayusculas (regex
+        // `^[A-Z0-9-]{5,50}$`).
+        assert_eq!(
+            client
+                .register_driver(
+                    "Carlos Perez",
+                    "carlos@example.com",
+                    "+573001234567",
+                    "motoya2026",
+                    "abc1234"
+                )
+                .await,
+            Err(RegisterError::InvalidLicenseNumber)
+        );
+        // Caracter fuera del set permitido.
+        assert_eq!(
+            client
+                .register_driver(
+                    "Carlos Perez",
+                    "carlos@example.com",
+                    "+573001234567",
+                    "motoya2026",
+                    "ABC 1234"
+                )
+                .await,
+            Err(RegisterError::InvalidLicenseNumber)
+        );
+    }
+
+    #[tokio::test]
+    async fn register_driver_returns_authenticated_user_on_success() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/register/driver"))
+            .and(body_json(serde_json::json!({
+                "name": "Carlos Perez",
+                "email": "carlos@example.com",
+                "phone": "+573001234567",
+                "password": "motoya2026",
+                "license_number": "ABC1234",
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "data": {
+                    "user": {
+                        "id": 2,
+                        "name": "Carlos Perez",
+                        "email": "carlos@example.com",
+                        "phone": "+573001234567",
+                        "role": "driver",
+                    },
+                    "token": {
+                        "access_token": "jwt-token",
+                        "token_type": "bearer",
+                        "expires_in": 900,
+                    },
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let authenticated = client
+            .register_driver(
+                "Carlos Perez",
+                "carlos@example.com",
+                "+573001234567",
+                "motoya2026",
+                "ABC1234",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(authenticated.user.email, "carlos@example.com");
+        assert_eq!(authenticated.user.role, Role::Driver);
+        assert_eq!(authenticated.token.access_token, "jwt-token");
+    }
+
+    #[tokio::test]
+    async fn register_driver_returns_validation_error_on_422() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/register/driver"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "The license number has already been taken.",
+                "errors": {
+                    "license_number": ["The license number has already been taken."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .register_driver(
+                "Carlos Perez",
+                "carlos@example.com",
+                "+573001234567",
+                "motoya2026",
+                "ABC1234",
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            RegisterError::Validation(ApiErrorBody {
+                message: "The license number has already been taken.".to_string(),
+                errors: Some(HashMap::from([(
+                    "license_number".to_string(),
+                    vec!["The license number has already been taken.".to_string()]
+                )])),
+            })
+        );
+        assert_eq!(
+            error.field_message("license_number"),
+            Some("The license number has already been taken.".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn register_driver_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .register_driver(
+                "Carlos Perez",
+                "carlos@example.com",
+                "+573001234567",
+                "motoya2026",
+                "ABC1234",
             )
             .await
             .unwrap_err();

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -75,6 +75,23 @@ pub struct RegisterPassengerPayload {
     pub password: String,
 }
 
+/// Body de `POST /api/v1/auth/register/driver`
+/// (`openapi.yaml#/components/schemas/DriverRegistrationRequest`).
+///
+/// `license_number` es obligatorio en el backend (`RegisterDriverRequest`,
+/// ver `Back_App_MotoCarros`) — sin el, la request siempre responde 422. En
+/// esta etapa de pruebas la UI lo pide como "Numero de documento" en vez de
+/// "licencia" (ver issue #7), pero viaja tal cual bajo el nombre de campo que
+/// espera el backend.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RegisterDriverPayload {
+    pub name: String,
+    pub email: String,
+    pub phone: String,
+    pub password: String,
+    pub license_number: String,
+}
+
 /// Body de `PATCH /api/v1/me`
 /// (`openapi.yaml#/components/schemas/UpdateProfileRequest`).
 ///

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -11,6 +11,7 @@ pub mod screens;
 pub use map::{MapMarker, MapView};
 pub use screens::login::LoginScreen;
 pub use screens::profile::ProfileScreen;
+pub use screens::register_driver::RegisterDriverScreen;
 pub use screens::register_passenger::RegisterPassengerScreen;
 pub use screens::ride_estimate::RideEstimateScreen;
 
@@ -19,6 +20,7 @@ pub use screens::ride_estimate::RideEstimateScreen;
 enum AuthScreen {
     Login,
     RegisterPassenger,
+    RegisterDriver,
 }
 
 /// Raiz de la UI, agnostica de plataforma.
@@ -50,10 +52,16 @@ pub fn App() -> Element {
                 AuthScreen::Login => rsx! {
                     LoginScreen {
                         on_register_click: move |_| auth_screen.set(AuthScreen::RegisterPassenger),
+                        on_register_driver_click: move |_| auth_screen.set(AuthScreen::RegisterDriver),
                     }
                 },
                 AuthScreen::RegisterPassenger => rsx! {
                     RegisterPassengerScreen {
+                        on_login_click: move |_| auth_screen.set(AuthScreen::Login),
+                    }
+                },
+                AuthScreen::RegisterDriver => rsx! {
+                    RegisterDriverScreen {
                         on_login_click: move |_| auth_screen.set(AuthScreen::Login),
                     }
                 },

--- a/crates/moto_ui/src/screens/login.rs
+++ b/crates/moto_ui/src/screens/login.rs
@@ -15,6 +15,9 @@ use moto_core::storage::TokenStorage;
 pub struct LoginScreenProps {
     /// Se dispara cuando el usuario pide ir a crear una cuenta de pasajero.
     pub on_register_click: EventHandler<()>,
+    /// Se dispara cuando el usuario pide ir a crear una cuenta de conductor
+    /// (issue #7).
+    pub on_register_driver_click: EventHandler<()>,
 }
 
 #[component]
@@ -91,6 +94,12 @@ pub fn LoginScreen(props: LoginScreenProps) -> Element {
                 class: "login-register-link",
                 onclick: move |_| props.on_register_click.call(()),
                 "Crear cuenta de pasajero"
+            }
+            button {
+                r#type: "button",
+                class: "login-register-driver-link",
+                onclick: move |_| props.on_register_driver_click.call(()),
+                "Crear cuenta de conductor"
             }
         }
     }

--- a/crates/moto_ui/src/screens/mod.rs
+++ b/crates/moto_ui/src/screens/mod.rs
@@ -1,4 +1,5 @@
 pub mod login;
 pub mod profile;
+pub mod register_driver;
 pub mod register_passenger;
 pub mod ride_estimate;

--- a/crates/moto_ui/src/screens/register_driver.rs
+++ b/crates/moto_ui/src/screens/register_driver.rs
@@ -1,0 +1,191 @@
+//! Pantalla de registro de conductor — issue #7.
+//!
+//! El registro del vehiculo es un paso aparte (issue #11, fuera de alcance
+//! aca): al registrarse exitosamente la sesion queda autenticada igual que
+//! tras un login (mismo shape `AuthenticatedUser`), sin importar si el
+//! conductor ya tiene o no un vehiculo cargado.
+//!
+//! El campo `license_number` que exige el backend (`RegisterDriverRequest`)
+//! se muestra en la UI como "Numero de documento", no "licencia" — decision
+//! explicita del dueno del repo para esta etapa de pruebas (ver comentario en
+//! el issue #7): cualquier numero de documento cabe en el formato que valida
+//! el backend.
+
+use std::sync::Arc;
+
+use dioxus::prelude::*;
+use moto_core::api::{ApiClient, RegisterError};
+use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
+
+#[derive(Props, Clone, PartialEq)]
+pub struct RegisterDriverScreenProps {
+    /// Se dispara cuando el usuario pide volver a la pantalla de login.
+    pub on_login_click: EventHandler<()>,
+}
+
+#[component]
+pub fn RegisterDriverScreen(props: RegisterDriverScreenProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut name = use_signal(String::new);
+    let mut email = use_signal(String::new);
+    let mut phone = use_signal(String::new);
+    let mut password = use_signal(String::new);
+    let mut license_number = use_signal(String::new);
+    let mut register_error = use_signal(|| None::<RegisterError>);
+    let mut is_loading = use_signal(|| false);
+
+    let on_submit = move |event: FormEvent| {
+        event.prevent_default();
+
+        let name_value = name();
+        let email_value = email();
+        let phone_value = phone();
+        let password_value = password();
+        let license_number_value = license_number();
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            register_error.set(None);
+
+            match api_client
+                .register_driver(
+                    &name_value,
+                    &email_value,
+                    &phone_value,
+                    &password_value,
+                    &license_number_value,
+                )
+                .await
+            {
+                Ok(authenticated) => {
+                    session.authenticate(authenticated, storage.as_ref());
+                }
+                Err(err) => {
+                    register_error.set(Some(err));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    };
+
+    let current_error = register_error();
+    let name_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("name"));
+    let email_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("email"));
+    let phone_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("phone"));
+    let password_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("password"));
+    let license_number_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("license_number"));
+    // El mensaje generico solo se muestra cuando el error no trae desglose
+    // campo por campo (p. ej. red, 5xx, o EmptyFields) para no repetir el
+    // mismo texto dos veces cuando ya se pinta junto al input afectado.
+    let has_field_errors = name_error.is_some()
+        || email_error.is_some()
+        || phone_error.is_some()
+        || password_error.is_some()
+        || license_number_error.is_some();
+    let general_message = if has_field_errors {
+        None
+    } else {
+        current_error.as_ref().map(|err| err.to_string())
+    };
+
+    rsx! {
+        div { class: "register-driver-screen",
+            h1 { "Crear cuenta de conductor" }
+            form { onsubmit: on_submit,
+                label { r#for: "register-driver-name", "Nombre" }
+                input {
+                    id: "register-driver-name",
+                    r#type: "text",
+                    autocomplete: "name",
+                    disabled: is_loading(),
+                    value: "{name}",
+                    oninput: move |event| name.set(event.value()),
+                }
+                if let Some(message) = &name_error {
+                    p { class: "register-driver-field-error", role: "alert", "{message}" }
+                }
+                label { r#for: "register-driver-email", "Email" }
+                input {
+                    id: "register-driver-email",
+                    r#type: "email",
+                    autocomplete: "username",
+                    disabled: is_loading(),
+                    value: "{email}",
+                    oninput: move |event| email.set(event.value()),
+                }
+                if let Some(message) = &email_error {
+                    p { class: "register-driver-field-error", role: "alert", "{message}" }
+                }
+                label { r#for: "register-driver-phone", "Telefono" }
+                input {
+                    id: "register-driver-phone",
+                    r#type: "tel",
+                    autocomplete: "tel",
+                    disabled: is_loading(),
+                    value: "{phone}",
+                    oninput: move |event| phone.set(event.value()),
+                }
+                if let Some(message) = &phone_error {
+                    p { class: "register-driver-field-error", role: "alert", "{message}" }
+                }
+                label { r#for: "register-driver-license-number", "Numero de documento" }
+                input {
+                    id: "register-driver-license-number",
+                    r#type: "text",
+                    autocomplete: "off",
+                    disabled: is_loading(),
+                    value: "{license_number}",
+                    oninput: move |event| license_number.set(event.value()),
+                }
+                if let Some(message) = &license_number_error {
+                    p { class: "register-driver-field-error", role: "alert", "{message}" }
+                }
+                label { r#for: "register-driver-password", "Contrasena" }
+                input {
+                    id: "register-driver-password",
+                    r#type: "password",
+                    autocomplete: "new-password",
+                    disabled: is_loading(),
+                    value: "{password}",
+                    oninput: move |event| password.set(event.value()),
+                }
+                if let Some(message) = &password_error {
+                    p { class: "register-driver-field-error", role: "alert", "{message}" }
+                }
+                button { r#type: "submit", disabled: is_loading(),
+                    if is_loading() {
+                        "Creando cuenta..."
+                    } else {
+                        "Crear cuenta"
+                    }
+                }
+            }
+            if let Some(message) = general_message {
+                p { class: "register-driver-error", role: "alert", "{message}" }
+            }
+            button {
+                r#type: "button",
+                class: "register-driver-login-link",
+                onclick: move |_| props.on_login_click.call(()),
+                "Ya tengo cuenta, iniciar sesion"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #7

## Qué hace

Agrega la pantalla y el cliente API para que un conductor pueda registrarse
con nombre, email, telefono, contrasena y numero de documento:

- `moto_core::api::ApiClient::register_driver` — `POST
  /api/v1/auth/register/driver`, con validacion en cliente de campos vacios,
  formato de email/telefono (mismas reglas que `register_passenger`) y
  formato de `license_number` (regex `^[A-Z0-9-]{5,50}$`, igual al que exige
  `RegisterDriverRequest` en el backend).
- `moto_core::models::RegisterDriverPayload` — body del endpoint.
- `moto_ui::screens::register_driver::RegisterDriverScreen` — formulario
  nuevo, mismo patron que `RegisterPassengerScreen` (estados de carga/error,
  errores por campo vs. mensaje general).
- `LoginScreen` gana un segundo link ("Crear cuenta de conductor") y `App`
  (en `moto_ui::lib`) gana el estado `AuthScreen::RegisterDriver` para
  navegar a la pantalla nueva.

### Decision sobre `license_number`

El endpoint real exige `license_number` (`RegisterDriverRequest` en
`Back_App_MotoCarros`), campo que la historia original no mencionaba. El
dueno del repo resolvio el gap en los comentarios del issue #7: se agrega a
este mismo issue, mostrado en la UI como **"Numero de documento"** (no
"licencia", para no confundir en esta etapa de pruebas) y enviado al backend
tal cual como `license_number`.

## Cómo se probó

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude mobile` (93 tests en `moto_core` + 8 en
  `moto_ui`, incluye 8 tests nuevos para `register_driver`: campos vacios,
  email/telefono/`license_number` invalidos, éxito, 422 de validacion y error
  de red)
- `cargo build --package web --target wasm32-unknown-unknown` (mismo comando
  que el job `build-web` del CI)

No se corrio el renderizado real en navegador (no bloquea el merge segun
`.claude/STANDARDS.md`, se valida aparte).

## Decisiones y riesgos

- `RegisterError` se reutiliza entre `register_passenger` y `register_driver`
  agregando la variante `InvalidLicenseNumber` — mismo tipo de error, un
  campo mas de validacion de formato en el cliente.
- La validacion de `license_number` en el cliente es estricta (solo
  mayusculas ASCII, digitos y guiones, 5-50 caracteres), replicando
  exactamente el regex del backend para dar el error temprano en vez de
  esperar el 422.
- No se toco el registro del vehiculo (issue #11, dependiente de este) ni el
  build de `mobile` (el issue no toca codigo especifico de esa plataforma).

🤖 Generated with [Claude Code](https://claude.com/claude-code)