### PR TITLE
feat(#11): registrarme como conductor - registrar mi vehiculo

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -6,9 +6,9 @@
 
 use crate::models::{
     ApiErrorBody, AuthToken, AuthenticatedUser, BroadcastAuthPayload, BroadcastAuthResponse,
-    Coordinates, DataEnvelope, LoginPayload, RegisterDriverPayload, RegisterPassengerPayload, Ride,
-    RideCancellation, RideEstimate, RideEstimateRequestPayload, RideRequestPayload,
-    UpdateProfilePayload, User,
+    Coordinates, DataEnvelope, LoginPayload, RegisterDriverPayload, RegisterPassengerPayload,
+    RegisterVehiclePayload, Ride, RideCancellation, RideEstimate, RideEstimateRequestPayload,
+    RideRequestPayload, UpdateProfilePayload, User, Vehicle,
 };
 
 #[cfg(test)]
@@ -149,6 +149,17 @@ fn is_valid_phone(phone: &str) -> bool {
 fn is_valid_license_number(license_number: &str) -> bool {
     (5..=50).contains(&license_number.len())
         && license_number
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// Mismo regex que `RegisterVehicleRequest` en el backend
+/// (`^[A-Z0-9-]{5,10}$`, ver issue #11): 5 a 10 caracteres, solo letras
+/// mayusculas ASCII, digitos y guiones. Se valida despues de normalizar a
+/// mayusculas (ver `RegisterVehiclePayload`), igual que hace el backend.
+fn is_valid_plate(plate: &str) -> bool {
+    (5..=10).contains(&plate.len())
+        && plate
             .chars()
             .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
 }
@@ -318,6 +329,83 @@ impl UpdateProfileError {
     pub fn field_message(&self, field: &str) -> Option<String> {
         match self {
             UpdateProfileError::Validation(body) => body
+                .errors
+                .as_ref()
+                .and_then(|errors| errors.get(field))
+                .and_then(|messages| messages.first())
+                .cloned(),
+            _ => None,
+        }
+    }
+}
+
+/// Fallos posibles de `POST /api/v1/me/vehicle` (issue #11).
+///
+/// `EmptyFields`/`InvalidPlate`/`InvalidYear` se detectan en el cliente antes
+/// de mandar la request (formato basico), sin duplicar las reglas completas
+/// del backend (unicidad de la placa, limite superior dinamico del anio) —
+/// esas siguen viajando como `Validation` en un 422. Un conductor que ya
+/// tiene vehiculo registrado tambien recibe un 422 de `Validation`, pero bajo
+/// la clave sintetica `vehicle` en vez de un campo del formulario
+/// (`RegisterVehicleRequest::after` en `Back_App_MotoCarros`) — actualizar el
+/// vehiculo existente es la historia #12, fuera de alcance aca.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RegisterVehicleError {
+    EmptyFields,
+    /// `plate` no cumple el formato que exige el backend
+    /// (`RegisterVehicleRequest`, regex `^[A-Z0-9-]{5,10}$`).
+    InvalidPlate,
+    /// `year` no es un numero de 4 digitos no anterior a 1970.
+    InvalidYear,
+    /// La cuenta no es de conductor (`VehiclePolicy::create` en el backend).
+    Forbidden,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for RegisterVehicleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RegisterVehicleError::EmptyFields => write!(f, "Completa todos los campos."),
+            RegisterVehicleError::InvalidPlate => {
+                write!(
+                    f,
+                    "Ingresa una placa valida (5 a 10 caracteres, solo letras, numeros y guiones)."
+                )
+            }
+            RegisterVehicleError::InvalidYear => {
+                write!(f, "Ingresa un anio valido (4 digitos, no anterior a 1970).")
+            }
+            RegisterVehicleError::Forbidden => {
+                write!(f, "Esta cuenta no puede registrar un vehiculo.")
+            }
+            RegisterVehicleError::Validation(body) => write!(f, "{}", body.message),
+            RegisterVehicleError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            RegisterVehicleError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            RegisterVehicleError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RegisterVehicleError {}
+
+impl RegisterVehicleError {
+    /// Mensaje de validacion especifico para `field`, igual que
+    /// `RegisterError::field_message`.
+    pub fn field_message(&self, field: &str) -> Option<String> {
+        match self {
+            RegisterVehicleError::Validation(body) => body
                 .errors
                 .as_ref()
                 .and_then(|errors| errors.get(field))
@@ -516,6 +604,13 @@ enum PostOutcome<T> {
 }
 
 enum PostRideOutcome<T> {
+    Success(T),
+    Unauthorized,
+    Forbidden,
+    Validation(ApiErrorBody),
+}
+
+enum PostVehicleOutcome<T> {
     Success(T),
     Unauthorized,
     Forbidden,
@@ -978,6 +1073,119 @@ impl ApiClient {
                 Ok(PatchOutcome::Validation(body))
             }
             other => Err(UpdateProfileError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/me/vehicle` — issue #11. El backend no acepta un
+    /// segundo registro para la misma cuenta (responde 422 bajo la clave
+    /// sintetica `vehicle`, ver `RegisterVehicleError`) — actualizar un
+    /// vehiculo ya registrado es la historia #12, fuera de alcance aca.
+    /// Reintenta una vez con refresh de token ante un 401, igual que
+    /// `request_ride`; un 403 (cuenta no conductora) o un 422 (validacion,
+    /// incluido el caso de vehiculo duplicado) nunca se reintentan.
+    pub async fn register_vehicle(
+        &self,
+        token: &AuthToken,
+        plate: &str,
+        model: &str,
+        year: &str,
+    ) -> Result<AuthenticatedFetch<Vehicle>, RegisterVehicleError> {
+        let plate = plate.trim().to_uppercase();
+        let model = model.trim();
+        let year = year.trim();
+
+        if plate.is_empty() || model.is_empty() || year.is_empty() {
+            return Err(RegisterVehicleError::EmptyFields);
+        }
+        if !is_valid_plate(&plate) {
+            return Err(RegisterVehicleError::InvalidPlate);
+        }
+        let Ok(year_number) = year.parse::<u16>() else {
+            return Err(RegisterVehicleError::InvalidYear);
+        };
+        if year_number < 1970 {
+            return Err(RegisterVehicleError::InvalidYear);
+        }
+
+        let payload = RegisterVehiclePayload {
+            plate,
+            model: model.to_string(),
+            year: year_number,
+        };
+
+        match self
+            .post_vehicle_with_token(&token.access_token, &payload)
+            .await?
+        {
+            PostVehicleOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            PostVehicleOutcome::Forbidden => return Err(RegisterVehicleError::Forbidden),
+            PostVehicleOutcome::Validation(body) => {
+                return Err(RegisterVehicleError::Validation(body));
+            }
+            PostVehicleOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| RegisterVehicleError::SessionExpired)?;
+
+        match self
+            .post_vehicle_with_token(&renewed.access_token, &payload)
+            .await?
+        {
+            PostVehicleOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            PostVehicleOutcome::Forbidden => Err(RegisterVehicleError::Forbidden),
+            PostVehicleOutcome::Validation(body) => Err(RegisterVehicleError::Validation(body)),
+            PostVehicleOutcome::Unauthorized => Err(RegisterVehicleError::SessionExpired),
+        }
+    }
+
+    async fn post_vehicle_with_token(
+        &self,
+        access_token: &str,
+        body: &RegisterVehiclePayload,
+    ) -> Result<PostVehicleOutcome<Vehicle>, RegisterVehicleError> {
+        let url = format!("{}/api/v1/me/vehicle", self.base_url);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|err| RegisterVehicleError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<Vehicle> = response
+                .json()
+                .await
+                .map_err(|err| RegisterVehicleError::Network(err.to_string()))?;
+            return Ok(PostVehicleOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(PostVehicleOutcome::Unauthorized),
+            403 => Ok(PostVehicleOutcome::Forbidden),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| RegisterVehicleError::Network(err.to_string()))?;
+                Ok(PostVehicleOutcome::Validation(body))
+            }
+            other => Err(RegisterVehicleError::Unexpected(other)),
         }
     }
 
@@ -2366,6 +2574,266 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, UpdateProfileError::Network(_)));
+    }
+
+    #[tokio::test]
+    async fn register_vehicle_rejects_empty_fields_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .register_vehicle(&sample_token(), "", "Bajaj Boxer CT 100", "2022")
+                .await,
+            Err(RegisterVehicleError::EmptyFields)
+        );
+        assert_eq!(
+            client
+                .register_vehicle(&sample_token(), "ABC12D", "", "2022")
+                .await,
+            Err(RegisterVehicleError::EmptyFields)
+        );
+        assert_eq!(
+            client
+                .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "")
+                .await,
+            Err(RegisterVehicleError::EmptyFields)
+        );
+    }
+
+    #[tokio::test]
+    async fn register_vehicle_rejects_invalid_plate_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .register_vehicle(&sample_token(), "AB", "Bajaj Boxer CT 100", "2022")
+                .await,
+            Err(RegisterVehicleError::InvalidPlate)
+        );
+        assert_eq!(
+            client
+                .register_vehicle(&sample_token(), "ABC 12D!", "Bajaj Boxer CT 100", "2022")
+                .await,
+            Err(RegisterVehicleError::InvalidPlate)
+        );
+    }
+
+    #[tokio::test]
+    async fn register_vehicle_rejects_invalid_year_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .register_vehicle(
+                    &sample_token(),
+                    "ABC12D",
+                    "Bajaj Boxer CT 100",
+                    "not-a-year"
+                )
+                .await,
+            Err(RegisterVehicleError::InvalidYear)
+        );
+        assert_eq!(
+            client
+                .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "1969")
+                .await,
+            Err(RegisterVehicleError::InvalidYear)
+        );
+    }
+
+    #[tokio::test]
+    async fn register_vehicle_normalizes_the_plate_and_returns_the_created_vehicle() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/vehicle"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .and(body_json(serde_json::json!({
+                "plate": "ABC12D",
+                "model": "Bajaj Boxer CT 100",
+                "year": 2022,
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "data": {
+                    "plate": "ABC12D",
+                    "model": "Bajaj Boxer CT 100",
+                    "year": 2022,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .register_vehicle(&sample_token(), " abc12d ", "Bajaj Boxer CT 100", "2022")
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.plate, "ABC12D");
+        assert_eq!(fetch.data.year, 2022);
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn register_vehicle_returns_forbidden_on_403_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/vehicle"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "2022")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, RegisterVehicleError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn register_vehicle_returns_validation_error_on_422_when_the_driver_already_has_a_vehicle()
+     {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/vehicle"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Ya tienes un vehiculo registrado; actualiza el existente en vez de registrar otro.",
+                "errors": {
+                    "vehicle": ["Ya tienes un vehiculo registrado; actualiza el existente en vez de registrar otro."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "2022")
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            RegisterVehicleError::Validation(ApiErrorBody {
+                message: "Ya tienes un vehiculo registrado; actualiza el existente en vez de registrar otro."
+                    .to_string(),
+                errors: Some(HashMap::from([(
+                    "vehicle".to_string(),
+                    vec![
+                        "Ya tienes un vehiculo registrado; actualiza el existente en vez de registrar otro."
+                            .to_string()
+                    ]
+                )])),
+            })
+        );
+        assert_eq!(error.field_message("plate"), None);
+    }
+
+    #[tokio::test]
+    async fn register_vehicle_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/vehicle"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/vehicle"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "data": {
+                    "plate": "ABC12D",
+                    "model": "Bajaj Boxer CT 100",
+                    "year": 2022,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "2022")
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.plate, "ABC12D");
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn register_vehicle_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/vehicle"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "2022")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, RegisterVehicleError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn register_vehicle_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "2022")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RegisterVehicleError::Network(_)));
     }
 
     fn sample_origin() -> Coordinates {

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -108,6 +108,31 @@ pub struct UpdateProfilePayload {
     pub phone: Option<String>,
 }
 
+/// Body de `POST /api/v1/me/vehicle`
+/// (`openapi.yaml#/components/schemas/VehicleRegistrationRequest`).
+///
+/// `plate` viaja ya normalizada (recortada y en mayusculas): el backend hace
+/// lo mismo antes de validar (`RegisterVehicleRequest::prepareForValidation`
+/// en `Back_App_MotoCarros`), asi que el cliente lo hace antes de mandar la
+/// request para que el valor mostrado y el guardado coincidan (issue #11).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RegisterVehiclePayload {
+    pub plate: String,
+    pub model: String,
+    pub year: u16,
+}
+
+/// `openapi.yaml#/components/schemas/Vehicle` — respuesta de
+/// `POST /api/v1/me/vehicle` (issue #11). Solo estos tres campos: el backend
+/// no expone `id`/`user_id`/timestamps en este recurso (`VehicleResource` en
+/// `Back_App_MotoCarros`).
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct Vehicle {
+    pub plate: String,
+    pub model: String,
+    pub year: u16,
+}
+
 /// Un punto geografico (`openapi.yaml#/components/schemas/Coordinates`), usado
 /// tanto en el origen como en el destino de `POST /api/v1/rides/estimate`
 /// (issue #13) y de `POST /api/v1/rides` (issue #14).
@@ -306,6 +331,43 @@ mod tests {
 
         assert_eq!(error.message, "El email o la contrasena no son correctos.");
         assert!(error.errors.is_none());
+    }
+
+    #[test]
+    fn register_vehicle_payload_serializes_plate_model_and_year() {
+        let payload = RegisterVehiclePayload {
+            plate: "ABC12D".to_string(),
+            model: "Bajaj Boxer CT 100".to_string(),
+            year: 2022,
+        };
+
+        let json = serde_json::to_value(&payload).unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "plate": "ABC12D",
+                "model": "Bajaj Boxer CT 100",
+                "year": 2022,
+            })
+        );
+    }
+
+    #[test]
+    fn deserializes_vehicle_envelope() {
+        let json = r#"{
+            "data": {
+                "plate": "ABC12D",
+                "model": "Bajaj Boxer CT 100",
+                "year": 2022
+            }
+        }"#;
+
+        let envelope: DataEnvelope<Vehicle> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(envelope.data.plate, "ABC12D");
+        assert_eq!(envelope.data.model, "Bajaj Boxer CT 100");
+        assert_eq!(envelope.data.year, 2022);
     }
 
     #[test]

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use dioxus::prelude::*;
 use moto_core::api::ApiClient;
+use moto_core::models::Role;
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
 
@@ -13,6 +14,7 @@ pub use screens::login::LoginScreen;
 pub use screens::profile::ProfileScreen;
 pub use screens::register_driver::RegisterDriverScreen;
 pub use screens::register_passenger::RegisterPassengerScreen;
+pub use screens::register_vehicle::RegisterVehicleScreen;
 pub use screens::ride_estimate::RideEstimateScreen;
 
 /// Pantallas del flujo de autenticacion, previas a tener sesion iniciada.
@@ -78,12 +80,18 @@ pub fn App() -> Element {
 enum HomeSection {
     Profile,
     RideEstimate,
+    Vehicle,
 }
 
 /// Pantalla principal tras iniciar sesion: perfil (issue #9), tarifa
 /// estimada (issue #13), mas el logout (issue #8), que no depende de ninguna
 /// seccion — cerrar sesion debe estar disponible desde el momento en que hay
 /// una sesion iniciada.
+///
+/// La seccion de vehiculo (issue #11) solo se ofrece cuando `session.user()`
+/// ya cargo (`GET /api/v1/me`, issue #9) y es una cuenta de conductor: un
+/// pasajero nunca ve el boton, y estructuralmente no puede llegar a
+/// `RegisterVehicleScreen` desde esta navegacion.
 #[component]
 fn Home() -> Element {
     let api_client = use_context::<ApiClient>();
@@ -91,6 +99,7 @@ fn Home() -> Element {
     let mut session = use_context::<SessionState>();
     let mut is_logging_out = use_signal(|| false);
     let mut section = use_signal(|| HomeSection::Profile);
+    let is_driver = session.user().is_some_and(|user| user.role == Role::Driver);
 
     let on_logout = move |_| {
         let api_client = api_client.clone();
@@ -131,6 +140,14 @@ fn Home() -> Element {
                     onclick: move |_| section.set(HomeSection::RideEstimate),
                     "Ver tarifa estimada"
                 }
+                if is_driver {
+                    button {
+                        r#type: "button",
+                        disabled: section() == HomeSection::Vehicle,
+                        onclick: move |_| section.set(HomeSection::Vehicle),
+                        "Registrar mi vehiculo"
+                    }
+                }
             }
             match section() {
                 HomeSection::Profile => rsx! {
@@ -138,6 +155,9 @@ fn Home() -> Element {
                 },
                 HomeSection::RideEstimate => rsx! {
                     RideEstimateScreen {}
+                },
+                HomeSection::Vehicle => rsx! {
+                    RegisterVehicleScreen {}
                 },
             }
             button {

--- a/crates/moto_ui/src/screens/mod.rs
+++ b/crates/moto_ui/src/screens/mod.rs
@@ -2,4 +2,5 @@ pub mod login;
 pub mod profile;
 pub mod register_driver;
 pub mod register_passenger;
+pub mod register_vehicle;
 pub mod ride_estimate;

--- a/crates/moto_ui/src/screens/register_vehicle.rs
+++ b/crates/moto_ui/src/screens/register_vehicle.rs
@@ -1,0 +1,165 @@
+//! Pantalla de registro de vehiculo (conductor) — issue #11.
+//!
+//! Solo alcanzable para conductores: `Home` (`moto_ui/src/lib.rs`) no ofrece
+//! esta seccion en la navegacion cuando `session.user()` no es una cuenta de
+//! conductor — ese es el criterio de aceptacion que evita que un pasajero
+//! llegue aca desde la UI. El backend igual rechaza con 403 a una cuenta no
+//! conductora que llegue por otra via (`VehiclePolicy::create`), pero la
+//! pantalla no depende de eso para ocultarse.
+//!
+//! Consume `POST /api/v1/me/vehicle` a traves de `ApiClient::register_vehicle`.
+//! Un conductor que ya tiene un vehiculo registrado recibe el 422 del backend
+//! (clave sintetica `vehicle`, no un campo del formulario) como mensaje
+//! general — actualizar el vehiculo existente es la historia #12, fuera de
+//! alcance aca.
+
+use std::sync::Arc;
+
+use dioxus::prelude::*;
+use moto_core::api::{ApiClient, RegisterVehicleError};
+use moto_core::models::Vehicle;
+use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
+
+#[component]
+pub fn RegisterVehicleScreen() -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut plate = use_signal(String::new);
+    let mut model = use_signal(String::new);
+    let mut year = use_signal(String::new);
+    let mut register_error = use_signal(|| None::<RegisterVehicleError>);
+    let mut is_loading = use_signal(|| false);
+    let mut registered_vehicle = use_signal(|| None::<Vehicle>);
+
+    let on_submit = move |event: FormEvent| {
+        event.prevent_default();
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        let plate_value = plate();
+        let model_value = model();
+        let year_value = year();
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            register_error.set(None);
+
+            match api_client
+                .register_vehicle(&token, &plate_value, &model_value, &year_value)
+                .await
+            {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    registered_vehicle.set(Some(fetch.data));
+                }
+                Err(RegisterVehicleError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    register_error.set(Some(err));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    };
+
+    if let Some(vehicle) = registered_vehicle() {
+        return rsx! {
+            div { class: "register-vehicle-screen",
+                h2 { "Vehiculo registrado" }
+                dl { class: "register-vehicle-result",
+                    dt { "Placa" }
+                    dd { "{vehicle.plate}" }
+                    dt { "Modelo" }
+                    dd { "{vehicle.model}" }
+                    dt { "Anio" }
+                    dd { "{vehicle.year}" }
+                }
+            }
+        };
+    }
+
+    let current_error = register_error();
+    let plate_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("plate"));
+    let model_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("model"));
+    let year_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("year"));
+    // Igual que en el registro de conductor (issue #7): el mensaje generico
+    // solo se muestra cuando el error no trae desglose campo por campo. Esto
+    // tambien cubre el caso de vehiculo duplicado (422 bajo la clave
+    // sintetica `vehicle`, que no coincide con ningun campo del formulario).
+    let has_field_errors = plate_error.is_some() || model_error.is_some() || year_error.is_some();
+    let general_message = if has_field_errors {
+        None
+    } else {
+        current_error.as_ref().map(|err| err.to_string())
+    };
+
+    rsx! {
+        div { class: "register-vehicle-screen",
+            h2 { "Registrar mi vehiculo" }
+            form { onsubmit: on_submit,
+                label { r#for: "register-vehicle-plate", "Placa" }
+                input {
+                    id: "register-vehicle-plate",
+                    r#type: "text",
+                    autocomplete: "off",
+                    disabled: is_loading(),
+                    value: "{plate}",
+                    oninput: move |event| plate.set(event.value()),
+                }
+                if let Some(message) = &plate_error {
+                    p { class: "register-vehicle-field-error", role: "alert", "{message}" }
+                }
+                label { r#for: "register-vehicle-model", "Modelo" }
+                input {
+                    id: "register-vehicle-model",
+                    r#type: "text",
+                    autocomplete: "off",
+                    disabled: is_loading(),
+                    value: "{model}",
+                    oninput: move |event| model.set(event.value()),
+                }
+                if let Some(message) = &model_error {
+                    p { class: "register-vehicle-field-error", role: "alert", "{message}" }
+                }
+                label { r#for: "register-vehicle-year", "Anio" }
+                input {
+                    id: "register-vehicle-year",
+                    r#type: "number",
+                    autocomplete: "off",
+                    disabled: is_loading(),
+                    value: "{year}",
+                    oninput: move |event| year.set(event.value()),
+                }
+                if let Some(message) = &year_error {
+                    p { class: "register-vehicle-field-error", role: "alert", "{message}" }
+                }
+                button { r#type: "submit", disabled: is_loading(),
+                    if is_loading() {
+                        "Registrando..."
+                    } else {
+                        "Registrar vehiculo"
+                    }
+                }
+            }
+            if let Some(message) = general_message {
+                p { class: "register-vehicle-error", role: "alert", "{message}" }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #11

## Que hace
Agrega el registro del vehiculo del conductor, consumiendo `POST /api/v1/me/vehicle` del backend.

- `moto_core::api::ApiClient::register_vehicle`: valida formato basico en el cliente (campos no vacios, placa `^[A-Z0-9-]{5,10}$` tras normalizar a mayusculas, anio numerico de al menos 1970) antes de mandar la request; reintenta una vez con refresh de token ante un 401, igual que el resto de las requests autenticadas del cliente (`request_ride`, `update_profile`). Un 403 (cuenta no conductora) o un 422 (validacion del backend, incluido el caso de vehiculo ya registrado) nunca se reintentan.
- `moto_core::models::{RegisterVehiclePayload, Vehicle}`: tipos que reflejan el contrato exacto de `POST /api/v1/me/vehicle` (`plate`/`model`/`year`, sin `id` ni timestamps, igual que `VehicleResource` en el backend).
- `moto_ui::screens::register_vehicle::RegisterVehicleScreen`: formulario de placa/modelo/anio con errores por campo (mismo patron que `RegisterDriverScreen`/`EditProfileForm`); el 422 de "ya tienes un vehiculo registrado" viaja bajo una clave sintetica `vehicle` que no coincide con ningun campo, asi que se muestra como mensaje general.
- `moto_ui::Home`: nueva seccion "Registrar mi vehiculo" en la navegacion, visible **solo** cuando `session.user().role == Role::Driver` — un pasajero no puede llegar a la pantalla desde la UI (criterio de aceptacion del issue). El backend igual protege el endpoint con `VehiclePolicy::create`, pero la navegacion no depende de eso.

## Como se probo
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude mobile` (112 tests, incluye 9 tests nuevos para `register_vehicle` en `moto_core::api` cubriendo campos vacios, placa/anio invalidos, normalizacion de placa, 403, 422 de vehiculo duplicado, retry-on-401, session expired y error de red; mas 2 tests nuevos de serializacion/deserializacion en `moto_core::models`)
- `cargo build --package web --target wasm32-unknown-unknown` (mismo comando que usa el CI)

## Decisiones y riesgos
- El limite superior dinamico del anio (`max: anio actual + 1` en el backend) no se duplica en el cliente porque requeriria una dependencia de fecha (`chrono`, no usada en este repo) solo para una regla que ya viaja como `Validation` en un 422 — mismo criterio que otras reglas de negocio no estaticas (unicidad de email/placa).
- La actualizacion de un vehiculo ya registrado (`PATCH /api/v1/me/vehicle`) es la historia #12, fuera de alcance aca: un conductor que reintenta el registro recibe el 422 del backend como mensaje general, sin una pantalla de edicion todavia.
- No hay endpoint para *ver* el vehiculo ya registrado por separado (`GET /me` no lo incluye, ver `ProfileResource` del backend), asi que la pantalla no distingue proactivamente "todavia no tiene vehiculo" de "ya tiene uno": simplemente ofrece el formulario y deja que el 422 informe el caso de duplicado.