### PR TITLE
feat(#12): actualizar datos de mi vehiculo

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -8,7 +8,7 @@ use crate::models::{
     ApiErrorBody, AuthToken, AuthenticatedUser, BroadcastAuthPayload, BroadcastAuthResponse,
     Coordinates, DataEnvelope, LoginPayload, RegisterDriverPayload, RegisterPassengerPayload,
     RegisterVehiclePayload, Ride, RideCancellation, RideEstimate, RideEstimateRequestPayload,
-    RideRequestPayload, UpdateProfilePayload, User, Vehicle,
+    RideRequestPayload, UpdateProfilePayload, UpdateVehiclePayload, User, Vehicle,
 };
 
 #[cfg(test)]
@@ -416,6 +416,125 @@ impl RegisterVehicleError {
     }
 }
 
+/// Fallos posibles de `GET /api/v1/me/vehicle` (issue #12).
+///
+/// `NotFound` es la senal que usa la UI para decidir si mostrar el
+/// formulario de registro (issue #11) o el de edicion (issue #12): un
+/// conductor sin vehiculo todavia recibe 404, no una lista vacia.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GetVehicleError {
+    /// La cuenta no es de conductor (`VehiclePolicy::create` en el backend).
+    Forbidden,
+    /// El conductor todavia no registro ningun vehiculo.
+    NotFound,
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for GetVehicleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GetVehicleError::Forbidden => {
+                write!(f, "Esta cuenta no puede tener un vehiculo registrado.")
+            }
+            GetVehicleError::NotFound => write!(f, "No tienes un vehiculo registrado."),
+            GetVehicleError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            GetVehicleError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            GetVehicleError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GetVehicleError {}
+
+/// Fallos posibles de `PATCH /api/v1/me/vehicle` (issue #12).
+///
+/// `NoFields` se detecta en el cliente antes de mandar la request, igual que
+/// `UpdateProfileError::NoFields` (issue #10). `InvalidPlate`/`InvalidYear`
+/// validan el mismo formato basico que `register_vehicle` (issue #11) antes
+/// de mandar la request — el resto (unicidad de la placa, limite superior
+/// dinamico del anio, cuenta sin vehiculo todavia) sigue viajando desde el
+/// backend (`Validation`/`NotFound`).
+#[derive(Debug, Clone, PartialEq)]
+pub enum UpdateVehicleError {
+    NoFields,
+    /// `plate` no cumple el formato que exige el backend
+    /// (`UpdateVehicleRequest`, regex `^[A-Z0-9-]{5,10}$`).
+    InvalidPlate,
+    /// `year` no es un numero de 4 digitos no anterior a 1970.
+    InvalidYear,
+    /// La cuenta no es de conductor (`VehiclePolicy::create` en el backend).
+    Forbidden,
+    /// El conductor todavia no registro ningun vehiculo (issue #11).
+    NotFound,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for UpdateVehicleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UpdateVehicleError::NoFields => write!(f, "No hay ningun cambio para guardar."),
+            UpdateVehicleError::InvalidPlate => {
+                write!(
+                    f,
+                    "Ingresa una placa valida (5 a 10 caracteres, solo letras, numeros y guiones)."
+                )
+            }
+            UpdateVehicleError::InvalidYear => {
+                write!(f, "Ingresa un anio valido (4 digitos, no anterior a 1970).")
+            }
+            UpdateVehicleError::Forbidden => {
+                write!(f, "Esta cuenta no puede actualizar un vehiculo.")
+            }
+            UpdateVehicleError::NotFound => write!(f, "No tienes un vehiculo registrado."),
+            UpdateVehicleError::Validation(body) => write!(f, "{}", body.message),
+            UpdateVehicleError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            UpdateVehicleError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            UpdateVehicleError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for UpdateVehicleError {}
+
+impl UpdateVehicleError {
+    /// Mensaje de validacion especifico para `field`, igual que
+    /// `RegisterVehicleError::field_message`.
+    pub fn field_message(&self, field: &str) -> Option<String> {
+        match self {
+            UpdateVehicleError::Validation(body) => body
+                .errors
+                .as_ref()
+                .and_then(|errors| errors.get(field))
+                .and_then(|messages| messages.first())
+                .cloned(),
+            _ => None,
+        }
+    }
+}
+
 /// Fallos posibles de `POST /api/v1/rides/estimate` (issue #14, consumido
 /// desde la app en issue #13).
 ///
@@ -614,6 +733,21 @@ enum PostVehicleOutcome<T> {
     Success(T),
     Unauthorized,
     Forbidden,
+    Validation(ApiErrorBody),
+}
+
+enum GetVehicleOutcome<T> {
+    Success(T),
+    Unauthorized,
+    Forbidden,
+    NotFound,
+}
+
+enum PatchVehicleOutcome<T> {
+    Success(T),
+    Unauthorized,
+    Forbidden,
+    NotFound,
     Validation(ApiErrorBody),
 }
 
@@ -1186,6 +1320,200 @@ impl ApiClient {
                 Ok(PostVehicleOutcome::Validation(body))
             }
             other => Err(RegisterVehicleError::Unexpected(other)),
+        }
+    }
+
+    /// `GET /api/v1/me/vehicle` — issue #12. Un `NotFound` (404) significa
+    /// que el conductor todavia no registro ningun vehiculo — la UI lo usa
+    /// para decidir entre mostrar el registro (issue #11) o la edicion
+    /// (issue #12). Reintenta una vez con refresh de token ante un 401,
+    /// igual que `me`; un 403 (cuenta no conductora) o un 404 nunca se
+    /// reintentan.
+    pub async fn get_vehicle(
+        &self,
+        token: &AuthToken,
+    ) -> Result<AuthenticatedFetch<Vehicle>, GetVehicleError> {
+        match self.get_vehicle_with_token(&token.access_token).await? {
+            GetVehicleOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            GetVehicleOutcome::Forbidden => return Err(GetVehicleError::Forbidden),
+            GetVehicleOutcome::NotFound => return Err(GetVehicleError::NotFound),
+            GetVehicleOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| GetVehicleError::SessionExpired)?;
+
+        match self.get_vehicle_with_token(&renewed.access_token).await? {
+            GetVehicleOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            GetVehicleOutcome::Forbidden => Err(GetVehicleError::Forbidden),
+            GetVehicleOutcome::NotFound => Err(GetVehicleError::NotFound),
+            GetVehicleOutcome::Unauthorized => Err(GetVehicleError::SessionExpired),
+        }
+    }
+
+    async fn get_vehicle_with_token(
+        &self,
+        access_token: &str,
+    ) -> Result<GetVehicleOutcome<Vehicle>, GetVehicleError> {
+        let url = format!("{}/api/v1/me/vehicle", self.base_url);
+
+        let response = self
+            .http
+            .get(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|err| GetVehicleError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<Vehicle> = response
+                .json()
+                .await
+                .map_err(|err| GetVehicleError::Network(err.to_string()))?;
+            return Ok(GetVehicleOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(GetVehicleOutcome::Unauthorized),
+            403 => Ok(GetVehicleOutcome::Forbidden),
+            404 => Ok(GetVehicleOutcome::NotFound),
+            other => Err(GetVehicleError::Unexpected(other)),
+        }
+    }
+
+    /// `PATCH /api/v1/me/vehicle` — issue #12. Mismo criterio que
+    /// `update_profile` (issue #10): PATCH parcial, reintenta una vez con
+    /// refresh de token ante un 401. A diferencia de `update_profile`,
+    /// valida `plate`/`year` con el mismo formato basico que
+    /// `register_vehicle` antes de mandar la request — el resto (unicidad de
+    /// la placa, limite superior del anio, cuenta sin vehiculo todavia)
+    /// sigue viajando desde el backend (403/404/422); esos nunca se
+    /// reintentan.
+    pub async fn update_vehicle(
+        &self,
+        token: &AuthToken,
+        plate: Option<&str>,
+        model: Option<&str>,
+        year: Option<&str>,
+    ) -> Result<AuthenticatedFetch<Vehicle>, UpdateVehicleError> {
+        if plate.is_none() && model.is_none() && year.is_none() {
+            return Err(UpdateVehicleError::NoFields);
+        }
+
+        let plate = match plate {
+            Some(value) => {
+                let value = value.trim().to_uppercase();
+                if !is_valid_plate(&value) {
+                    return Err(UpdateVehicleError::InvalidPlate);
+                }
+                Some(value)
+            }
+            None => None,
+        };
+        let model = model.map(|value| value.trim().to_string());
+        let year = match year {
+            Some(value) => {
+                let Ok(year_number) = value.trim().parse::<u16>() else {
+                    return Err(UpdateVehicleError::InvalidYear);
+                };
+                if year_number < 1970 {
+                    return Err(UpdateVehicleError::InvalidYear);
+                }
+                Some(year_number)
+            }
+            None => None,
+        };
+
+        let payload = UpdateVehiclePayload { plate, model, year };
+
+        match self
+            .patch_vehicle_with_token(&token.access_token, &payload)
+            .await?
+        {
+            PatchVehicleOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            PatchVehicleOutcome::Forbidden => return Err(UpdateVehicleError::Forbidden),
+            PatchVehicleOutcome::NotFound => return Err(UpdateVehicleError::NotFound),
+            PatchVehicleOutcome::Validation(body) => {
+                return Err(UpdateVehicleError::Validation(body));
+            }
+            PatchVehicleOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| UpdateVehicleError::SessionExpired)?;
+
+        match self
+            .patch_vehicle_with_token(&renewed.access_token, &payload)
+            .await?
+        {
+            PatchVehicleOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            PatchVehicleOutcome::Forbidden => Err(UpdateVehicleError::Forbidden),
+            PatchVehicleOutcome::NotFound => Err(UpdateVehicleError::NotFound),
+            PatchVehicleOutcome::Validation(body) => Err(UpdateVehicleError::Validation(body)),
+            PatchVehicleOutcome::Unauthorized => Err(UpdateVehicleError::SessionExpired),
+        }
+    }
+
+    async fn patch_vehicle_with_token(
+        &self,
+        access_token: &str,
+        body: &UpdateVehiclePayload,
+    ) -> Result<PatchVehicleOutcome<Vehicle>, UpdateVehicleError> {
+        let url = format!("{}/api/v1/me/vehicle", self.base_url);
+
+        let response = self
+            .http
+            .patch(url)
+            .bearer_auth(access_token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|err| UpdateVehicleError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<Vehicle> = response
+                .json()
+                .await
+                .map_err(|err| UpdateVehicleError::Network(err.to_string()))?;
+            return Ok(PatchVehicleOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(PatchVehicleOutcome::Unauthorized),
+            403 => Ok(PatchVehicleOutcome::Forbidden),
+            404 => Ok(PatchVehicleOutcome::NotFound),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| UpdateVehicleError::Network(err.to_string()))?;
+                Ok(PatchVehicleOutcome::Validation(body))
+            }
+            other => Err(UpdateVehicleError::Unexpected(other)),
         }
     }
 
@@ -2834,6 +3162,392 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, RegisterVehicleError::Network(_)));
+    }
+
+    #[tokio::test]
+    async fn get_vehicle_returns_the_registered_vehicle() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/vehicle"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "plate": "ABC12D",
+                    "model": "Bajaj Boxer CT 100",
+                    "year": 2022,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.get_vehicle(&sample_token()).await.unwrap();
+
+        assert_eq!(fetch.data.plate, "ABC12D");
+        assert_eq!(fetch.data.year, 2022);
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn get_vehicle_returns_not_found_when_the_driver_has_no_vehicle() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/vehicle"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "No tienes un vehiculo registrado.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.get_vehicle(&sample_token()).await.unwrap_err();
+
+        assert_eq!(error, GetVehicleError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn get_vehicle_returns_forbidden_on_403_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/vehicle"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.get_vehicle(&sample_token()).await.unwrap_err();
+
+        assert_eq!(error, GetVehicleError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn get_vehicle_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/vehicle"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/vehicle"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "plate": "ABC12D",
+                    "model": "Bajaj Boxer CT 100",
+                    "year": 2022,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.get_vehicle(&sample_token()).await.unwrap();
+
+        assert_eq!(fetch.data.plate, "ABC12D");
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn get_vehicle_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/vehicle"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.get_vehicle(&sample_token()).await.unwrap_err();
+
+        assert_eq!(error, GetVehicleError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn get_vehicle_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client.get_vehicle(&sample_token()).await.unwrap_err();
+
+        assert!(matches!(error, GetVehicleError::Network(_)));
+    }
+
+    #[tokio::test]
+    async fn update_vehicle_rejects_an_empty_patch_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        let error = client
+            .update_vehicle(&sample_token(), None, None, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, UpdateVehicleError::NoFields);
+    }
+
+    #[tokio::test]
+    async fn update_vehicle_rejects_invalid_plate_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        let error = client
+            .update_vehicle(&sample_token(), Some("AB"), None, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, UpdateVehicleError::InvalidPlate);
+    }
+
+    #[tokio::test]
+    async fn update_vehicle_rejects_invalid_year_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .update_vehicle(&sample_token(), None, None, Some("not-a-year"))
+                .await,
+            Err(UpdateVehicleError::InvalidYear)
+        );
+        assert_eq!(
+            client
+                .update_vehicle(&sample_token(), None, None, Some("1969"))
+                .await,
+            Err(UpdateVehicleError::InvalidYear)
+        );
+    }
+
+    #[tokio::test]
+    async fn update_vehicle_sends_only_the_present_fields_and_returns_the_updated_vehicle() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/me/vehicle"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .and(body_json(serde_json::json!({
+                "plate": "ABC12D",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "plate": "ABC12D",
+                    "model": "Bajaj Boxer CT 100",
+                    "year": 2022,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .update_vehicle(&sample_token(), Some(" abc12d "), None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.plate, "ABC12D");
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn update_vehicle_returns_not_found_when_the_driver_has_no_vehicle() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/me/vehicle"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "No tienes un vehiculo registrado; registralo antes de actualizarlo.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .update_vehicle(&sample_token(), Some("ABC12D"), None, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, UpdateVehicleError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn update_vehicle_returns_validation_error_on_422_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/me/vehicle"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "The plate has already been taken.",
+                "errors": {
+                    "plate": ["The plate has already been taken."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .update_vehicle(&sample_token(), Some("ABC12D"), None, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            UpdateVehicleError::Validation(ApiErrorBody {
+                message: "The plate has already been taken.".to_string(),
+                errors: Some(HashMap::from([(
+                    "plate".to_string(),
+                    vec!["The plate has already been taken.".to_string()]
+                )])),
+            })
+        );
+        assert_eq!(
+            error.field_message("plate"),
+            Some("The plate has already been taken.".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn update_vehicle_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/me/vehicle"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/me/vehicle"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "plate": "ABC12D",
+                    "model": "Bajaj Boxer CT 100",
+                    "year": 2022,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .update_vehicle(&sample_token(), Some("ABC12D"), None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.plate, "ABC12D");
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn update_vehicle_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("PATCH"))
+            .and(path("/api/v1/me/vehicle"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .update_vehicle(&sample_token(), Some("ABC12D"), None, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, UpdateVehicleError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn update_vehicle_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .update_vehicle(&sample_token(), Some("ABC12D"), None, None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, UpdateVehicleError::Network(_)));
     }
 
     fn sample_origin() -> Coordinates {

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -123,14 +123,31 @@ pub struct RegisterVehiclePayload {
 }
 
 /// `openapi.yaml#/components/schemas/Vehicle` — respuesta de
-/// `POST /api/v1/me/vehicle` (issue #11). Solo estos tres campos: el backend
-/// no expone `id`/`user_id`/timestamps en este recurso (`VehicleResource` en
-/// `Back_App_MotoCarros`).
+/// `POST /api/v1/me/vehicle` (issue #11) y tambien de `GET`/`PATCH
+/// /api/v1/me/vehicle` (issue #12): las tres operaciones comparten el mismo
+/// `VehicleResource` del lado del backend. Solo estos tres campos: no expone
+/// `id`/`user_id`/timestamps.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Vehicle {
     pub plate: String,
     pub model: String,
     pub year: u16,
+}
+
+/// Body de `PATCH /api/v1/me/vehicle` (issue #12).
+///
+/// PATCH parcial, mismo criterio que `UpdateProfilePayload` (issue #10):
+/// cada campo ausente se omite del JSON en vez de viajar como `null`, para
+/// que el backend conserve el valor actual en vez de interpretarlo como
+/// "borrar este dato".
+#[derive(Debug, Clone, Serialize, PartialEq, Default)]
+pub struct UpdateVehiclePayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plate: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub year: Option<u16>,
 }
 
 /// Un punto geografico (`openapi.yaml#/components/schemas/Coordinates`), usado

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -16,6 +16,7 @@ pub use screens::register_driver::RegisterDriverScreen;
 pub use screens::register_passenger::RegisterPassengerScreen;
 pub use screens::register_vehicle::RegisterVehicleScreen;
 pub use screens::ride_estimate::RideEstimateScreen;
+pub use screens::vehicle::VehicleScreen;
 
 /// Pantallas del flujo de autenticacion, previas a tener sesion iniciada.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -88,10 +89,10 @@ enum HomeSection {
 /// seccion — cerrar sesion debe estar disponible desde el momento en que hay
 /// una sesion iniciada.
 ///
-/// La seccion de vehiculo (issue #11) solo se ofrece cuando `session.user()`
-/// ya cargo (`GET /api/v1/me`, issue #9) y es una cuenta de conductor: un
-/// pasajero nunca ve el boton, y estructuralmente no puede llegar a
-/// `RegisterVehicleScreen` desde esta navegacion.
+/// La seccion de vehiculo (issues #11 y #12, `VehicleScreen`) solo se ofrece
+/// cuando `session.user()` ya cargo (`GET /api/v1/me`, issue #9) y es una
+/// cuenta de conductor: un pasajero nunca ve el boton, y estructuralmente no
+/// puede llegar a esa pantalla desde esta navegacion.
 #[component]
 fn Home() -> Element {
     let api_client = use_context::<ApiClient>();
@@ -145,7 +146,7 @@ fn Home() -> Element {
                         r#type: "button",
                         disabled: section() == HomeSection::Vehicle,
                         onclick: move |_| section.set(HomeSection::Vehicle),
-                        "Registrar mi vehiculo"
+                        "Mi vehiculo"
                     }
                 }
             }
@@ -157,7 +158,7 @@ fn Home() -> Element {
                     RideEstimateScreen {}
                 },
                 HomeSection::Vehicle => rsx! {
-                    RegisterVehicleScreen {}
+                    VehicleScreen {}
                 },
             }
             button {

--- a/crates/moto_ui/src/screens/mod.rs
+++ b/crates/moto_ui/src/screens/mod.rs
@@ -4,3 +4,4 @@ pub mod register_driver;
 pub mod register_passenger;
 pub mod register_vehicle;
 pub mod ride_estimate;
+pub mod vehicle;

--- a/crates/moto_ui/src/screens/vehicle.rs
+++ b/crates/moto_ui/src/screens/vehicle.rs
@@ -1,0 +1,243 @@
+//! Pantalla de vehiculo (conductor): registra el vehiculo si todavia no
+//! tiene uno (issue #11, `RegisterVehicleScreen`) o permite corregir sus
+//! datos si ya lo tiene (issue #12).
+//!
+//! Al entrar, consulta `GET /api/v1/me/vehicle` para decidir cual de las dos
+//! mostrar: un 404 (`GetVehicleError::NotFound`) significa que el conductor
+//! todavia no registro nada — ese es el criterio de aceptacion que evita que
+//! la pantalla de edicion sea alcanzable sin vehiculo, sin depender de una
+//! bandera local que se perdería al desmontar el componente (`Home`, en
+//! `moto_ui/src/lib.rs`, desmonta cada seccion al cambiar de pestaña).
+//! Cualquier otro resultado exitoso es el vehiculo ya registrado, precargado
+//! en el formulario de edicion.
+
+use std::sync::Arc;
+
+use dioxus::prelude::*;
+use moto_core::api::{ApiClient, GetVehicleError, UpdateVehicleError};
+use moto_core::models::Vehicle;
+use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
+
+use super::register_vehicle::RegisterVehicleScreen;
+
+#[component]
+pub fn VehicleScreen() -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut is_loading = use_signal(|| false);
+    let mut load_error = use_signal(|| None::<String>);
+    let mut vehicle = use_signal(|| None::<Vehicle>);
+    let mut not_registered = use_signal(|| false);
+    // Misma guarda que `ProfileScreen` (issue #9): el efecto lee
+    // `session.token()` en su primera corrida, lo que lo suscribe a ese
+    // signal, y el fetch puede terminar escribiendo en `session` (refresh de
+    // token, logout) — sin esta bandera reprogramaria el efecto en un loop.
+    let mut has_fetched = use_signal(|| false);
+
+    use_effect(move || {
+        if has_fetched() {
+            return;
+        }
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        has_fetched.set(true);
+
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            load_error.set(None);
+
+            match api_client.get_vehicle(&token).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    vehicle.set(Some(fetch.data));
+                }
+                Err(GetVehicleError::NotFound) => {
+                    not_registered.set(true);
+                }
+                Err(GetVehicleError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    load_error.set(Some(err.to_string()));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    });
+
+    rsx! {
+        if not_registered() {
+            RegisterVehicleScreen {}
+        } else if is_loading() {
+            div { class: "vehicle-screen", p { "Cargando vehiculo..." } }
+        } else if let Some(message) = load_error() {
+            div { class: "vehicle-screen",
+                p { class: "vehicle-error", role: "alert", "{message}" }
+            }
+        } else if let Some(current) = vehicle() {
+            EditVehicleForm { vehicle: current }
+        }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct EditVehicleFormProps {
+    vehicle: Vehicle,
+}
+
+/// Formulario de edicion de placa/modelo/anio — issue #12. Precargado con
+/// `props.vehicle`; al guardar manda los tres campos a
+/// `ApiClient::update_vehicle` (PATCH parcial, mismo criterio que
+/// `EditProfileForm` en `profile.rs`: el formulario siempre esta
+/// completamente precargado, asi que ningun campo queda realmente ausente).
+#[component]
+fn EditVehicleForm(props: EditVehicleFormProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut plate = use_signal(|| props.vehicle.plate.clone());
+    let mut model = use_signal(|| props.vehicle.model.clone());
+    let mut year = use_signal(|| props.vehicle.year.to_string());
+    let mut update_error = use_signal(|| None::<UpdateVehicleError>);
+    let mut is_saving = use_signal(|| false);
+    let mut updated_vehicle = use_signal(|| None::<Vehicle>);
+
+    let on_submit = move |event: FormEvent| {
+        event.prevent_default();
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        let plate_value = plate();
+        let model_value = model();
+        let year_value = year();
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_saving.set(true);
+            update_error.set(None);
+
+            match api_client
+                .update_vehicle(
+                    &token,
+                    Some(&plate_value),
+                    Some(&model_value),
+                    Some(&year_value),
+                )
+                .await
+            {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    updated_vehicle.set(Some(fetch.data));
+                }
+                Err(UpdateVehicleError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    update_error.set(Some(err));
+                }
+            }
+
+            is_saving.set(false);
+        });
+    };
+
+    let current_error = update_error();
+    let plate_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("plate"));
+    let model_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("model"));
+    let year_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("year"));
+    // Igual que en `EditProfileForm` (issue #10): el mensaje generico solo
+    // se muestra cuando el error no trae desglose campo por campo.
+    let has_field_errors = plate_error.is_some() || model_error.is_some() || year_error.is_some();
+    let general_message = if has_field_errors {
+        None
+    } else {
+        current_error.as_ref().map(|err| err.to_string())
+    };
+
+    rsx! {
+        div { class: "vehicle-screen",
+            h2 { "Mi vehiculo" }
+            if let Some(vehicle) = updated_vehicle() {
+                dl { class: "update-vehicle-result",
+                    dt { "Placa" }
+                    dd { "{vehicle.plate}" }
+                    dt { "Modelo" }
+                    dd { "{vehicle.model}" }
+                    dt { "Anio" }
+                    dd { "{vehicle.year}" }
+                }
+            } else {
+                form { class: "update-vehicle-form", onsubmit: on_submit,
+                    label { r#for: "update-vehicle-plate", "Placa" }
+                    input {
+                        id: "update-vehicle-plate",
+                        r#type: "text",
+                        autocomplete: "off",
+                        disabled: is_saving(),
+                        value: "{plate}",
+                        oninput: move |event| plate.set(event.value()),
+                    }
+                    if let Some(message) = &plate_error {
+                        p { class: "update-vehicle-field-error", role: "alert", "{message}" }
+                    }
+                    label { r#for: "update-vehicle-model", "Modelo" }
+                    input {
+                        id: "update-vehicle-model",
+                        r#type: "text",
+                        autocomplete: "off",
+                        disabled: is_saving(),
+                        value: "{model}",
+                        oninput: move |event| model.set(event.value()),
+                    }
+                    if let Some(message) = &model_error {
+                        p { class: "update-vehicle-field-error", role: "alert", "{message}" }
+                    }
+                    label { r#for: "update-vehicle-year", "Anio" }
+                    input {
+                        id: "update-vehicle-year",
+                        r#type: "number",
+                        autocomplete: "off",
+                        disabled: is_saving(),
+                        value: "{year}",
+                        oninput: move |event| year.set(event.value()),
+                    }
+                    if let Some(message) = &year_error {
+                        p { class: "update-vehicle-field-error", role: "alert", "{message}" }
+                    }
+                    button { r#type: "submit", disabled: is_saving(),
+                        if is_saving() {
+                            "Guardando..."
+                        } else {
+                            "Guardar cambios"
+                        }
+                    }
+                }
+                if let Some(message) = general_message {
+                    p { class: "update-vehicle-error", role: "alert", "{message}" }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #12

## Qué hace

Agrega la posibilidad de corregir los datos del vehículo ya registrado
(placa/modelo/año), consumiendo el contrato que expone
`Back_App_MotoCarros` desde su PR #61
(`Back_App_MotoCarros#61`, que agregó `GET /api/v1/me/vehicle`):

- `ApiClient::get_vehicle` (`GET /api/v1/me/vehicle`, `GetVehicleError`):
  reintenta una vez con refresh de token ante un 401, igual que el resto
  del cliente; un 403 (cuenta no conductora) o un 404 (sin vehículo
  todavía) nunca se reintentan.
- `ApiClient::update_vehicle` (`PATCH /api/v1/me/vehicle`,
  `UpdateVehicleError`, `UpdateVehiclePayload`): PATCH parcial, mismo
  criterio que `update_profile` (issue #10). Valida `plate`/`year` con el
  mismo formato básico que `register_vehicle` (issue #11) antes de mandar
  la request.
- `VehicleScreen` (`crates/moto_ui/src/screens/vehicle.rs`): al entrar,
  consulta `GET /me/vehicle` y decide qué mostrar — un 404 renderiza
  `RegisterVehicleScreen` (issue #11) sin cambios; cualquier otro
  resultado exitoso precarga el formulario de edición
  (`EditVehicleForm`). Reemplaza a `RegisterVehicleScreen` como la
  pantalla de la sección "Mi vehículo" en `Home` (`moto_ui/src/lib.rs`).

## Cómo se probó

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude mobile` (119 tests en `moto_core`,
  incluyendo 17 nuevos para `get_vehicle`/`update_vehicle` con HTTP
  mockeado vía `wiremock`: éxito, 403, 404, 401+refresh,
  `SessionExpired`, red inalcanzable, y 422 con desglose por campo)
- `dx build --platform web --package web` compila sin errores

No se agregaron tests de UI: no existe scaffolding de tests para
`moto_ui` en este repo (ni `ProfileScreen` ni `RegisterVehicleScreen` lo
tienen), consistente con el criterio ya establecido.

## Decisiones y riesgos

- **Formulario "precargado" enviando siempre los tres campos**: el
  criterio de aceptación original pedía "enviar solo los campos
  presentes (PATCH parcial)". Sigo el mismo criterio ya establecido por
  `EditProfileForm` (issue #10): el formulario de edición está siempre
  completamente precargado, así que ningún campo queda realmente
  "ausente" — se manda `Some(valor_actual)` para los tres. El soporte de
  PATCH parcial real (`UpdateVehiclePayload` con campos `Option`) queda
  disponible en `ApiClient::update_vehicle` para quien quiera enviar un
  subconjunto, pero la UI no lo ejercita hoy, igual que pasa con el
  perfil.
- **Sin bandera local de "ya tiene vehículo"**: el gap que tenía
  bloqueado este issue (y el #16 espejo) era justamente la falta de un
  `GET /me/vehicle` — ya resuelto en `Back_App_MotoCarros#61`. La
  decisión de fondo (`GET` como fuente de verdad en vez de un flag de
  sesión) queda documentada en el comentario que dejé en el issue al
  reportar el gap originalmente.
- **`VehicleScreen` envuelve a `RegisterVehicleScreen` en vez de
  fusionarlas**: mantiene `RegisterVehicleScreen` intacta (issue #11, sin
  tocar su alcance) y agrega la decisión de qué mostrar en un componente
  nuevo — mismo patrón que ya usa `ProfileScreen` para alternar entre
  vista y edición.