### PR TITLE
feat(#16): recibir solicitudes de viaje cercanas (conductor)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "js-sys",
  "lazy-js-bundle",
  "rustc-hash 2.1.3",
@@ -1867,6 +1867,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+dependencies = [
+ "gloo-timers 0.4.0",
+ "send_wrapper",
+]
+
+[[package]]
 name = "futures-util"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,6 +2199,18 @@ name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3222,6 +3244,7 @@ name = "moto_ui"
 version = "0.1.0"
 dependencies = [
  "dioxus",
+ "futures-timer",
  "moto_core",
  "serde",
  "serde_json",

--- a/crates/mobile/src/main.rs
+++ b/crates/mobile/src/main.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use dioxus::prelude::*;
 use moto_core::api::ApiClient;
+use moto_core::realtime::RealtimeConfig;
 use moto_core::storage::{InMemoryTokenStorage, TokenStorage};
 use moto_ui::App;
 
@@ -14,9 +15,19 @@ fn main() {
     let base_url = option_env!("MOTOYA_API_BASE_URL")
         .unwrap_or(DEFAULT_API_BASE_URL)
         .to_string();
+    // Sin fallback de desarrollo local a proposito: la URL incluye la app key
+    // de Reverb, un secreto por entorno sin valor por defecto (ver
+    // `RealtimeConfig`). `None` hasta que el entorno configure
+    // `MOTOYA_WS_URL`.
+    let ws_url = option_env!("MOTOYA_WS_URL").map(str::to_string);
 
     LaunchBuilder::new()
         .with_context_provider(move || Box::new(ApiClient::new(base_url.clone())))
+        .with_context_provider(move || {
+            Box::new(RealtimeConfig {
+                ws_url: ws_url.clone(),
+            })
+        })
         // TODO(issue de seguimiento): esto deberia usar el keychain de iOS /
         // el keystore de Android en vez de memoria. Todavia no hay puente
         // nativo (proyecto Xcode/Gradle) en este esqueleto para exponer esas

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -288,6 +288,29 @@ pub struct BroadcastAuthResponse {
     pub auth: String,
 }
 
+/// Payload del evento `ride.requested`, publicado sobre el canal privado
+/// `driver.{id}` (`id` = `User.id` del conductor, no el de `driver_profiles`)
+/// cuando hay un viaje nuevo cerca (issue #16). Sin envelope `data`: viaja tal
+/// cual lo publica `app/Events/Realtime/RideRequested.php` de
+/// `Back_App_MotoCarros` dentro del frame de Pusher, no como respuesta HTTP.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct NearbyRideRequest {
+    pub ride_id: u64,
+    pub origin: Coordinates,
+    pub destination: Coordinates,
+    pub currency: String,
+    pub estimated_fare: i64,
+}
+
+/// Payload del evento `ride.unavailable` sobre el mismo canal `driver.{id}`:
+/// otro conductor acepto `ride_id` primero, asi que ya no esta disponible
+/// (`app/Events/Realtime/RideNoLongerAvailable.php` de
+/// `Back_App_MotoCarros`, issue #16).
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+pub struct RideNoLongerAvailable {
+    pub ride_id: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -602,5 +625,32 @@ mod tests {
         let response: BroadcastAuthResponse = serde_json::from_str(json).unwrap();
 
         assert_eq!(response.auth, "motoya-local:8f3c1a2b4d5e6f70");
+    }
+
+    #[test]
+    fn deserializes_nearby_ride_request_without_a_data_envelope() {
+        let json = r#"{
+            "ride_id": 7,
+            "origin": {"latitude": 4.710989, "longitude": -74.072092},
+            "destination": {"latitude": 4.698, "longitude": -74.061},
+            "currency": "COP",
+            "estimated_fare": 8850
+        }"#;
+
+        let request: NearbyRideRequest = serde_json::from_str(json).unwrap();
+
+        assert_eq!(request.ride_id, 7);
+        assert_eq!(request.currency, "COP");
+        assert_eq!(request.estimated_fare, 8850);
+        assert_eq!(request.origin.latitude, 4.710989);
+    }
+
+    #[test]
+    fn deserializes_ride_no_longer_available() {
+        let json = r#"{"ride_id": 7}"#;
+
+        let event: RideNoLongerAvailable = serde_json::from_str(json).unwrap();
+
+        assert_eq!(event.ride_id, 7);
     }
 }

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -311,6 +311,42 @@ pub struct RideNoLongerAvailable {
     pub ride_id: u64,
 }
 
+/// Aplica un evento del canal `driver.{id}` (issue #16) a la lista de
+/// solicitudes cercanas que ve un conductor, deduplicando por `ride_id`.
+///
+/// Logica pura y sincronica a proposito: es la maquina de estados que
+/// consume `NearbyRidesList` (`moto_ui`) en cada vuelta de su loop de
+/// sondeo sobre `RealtimeClient::poll_events()`, extraida de la pantalla
+/// para poder testearla sin Dioxus ni un socket real (ver review de la PR
+/// del issue #16: dos bugs de esta clase — `Reconnecting` que nunca
+/// reconectaba y `subscribe()` reintentado para siempre tras un fallo de
+/// auth — se detectaron solo por revision manual). `event_name`/`data` ya
+/// vienen filtrados por `channel` en el caller; un `data` que no
+/// deserializa al tipo esperado (frame corrupto o version del protocolo
+/// que este cliente no entiende) se ignora sin error, igual que
+/// `RealtimeClient::handle_frame`.
+pub fn apply_nearby_ride_event(
+    requests: &mut Vec<NearbyRideRequest>,
+    event_name: &str,
+    data: &str,
+) {
+    match event_name {
+        "ride.requested" => {
+            if let Ok(request) = serde_json::from_str::<NearbyRideRequest>(data)
+                && !requests.iter().any(|r| r.ride_id == request.ride_id)
+            {
+                requests.push(request);
+            }
+        }
+        "ride.unavailable" => {
+            if let Ok(gone) = serde_json::from_str::<RideNoLongerAvailable>(data) {
+                requests.retain(|r| r.ride_id != gone.ride_id);
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -652,5 +688,87 @@ mod tests {
         let event: RideNoLongerAvailable = serde_json::from_str(json).unwrap();
 
         assert_eq!(event.ride_id, 7);
+    }
+
+    fn nearby_ride_request_json(ride_id: u64) -> String {
+        serde_json::json!({
+            "ride_id": ride_id,
+            "origin": {"latitude": 4.710989, "longitude": -74.072092},
+            "destination": {"latitude": 4.698, "longitude": -74.061},
+            "currency": "COP",
+            "estimated_fare": 8850,
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn apply_nearby_ride_event_adds_a_ride_requested_event() {
+        let mut requests = Vec::new();
+
+        apply_nearby_ride_event(
+            &mut requests,
+            "ride.requested",
+            &nearby_ride_request_json(7),
+        );
+
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].ride_id, 7);
+    }
+
+    #[test]
+    fn apply_nearby_ride_event_deduplicates_by_ride_id() {
+        let mut requests = Vec::new();
+        apply_nearby_ride_event(
+            &mut requests,
+            "ride.requested",
+            &nearby_ride_request_json(7),
+        );
+
+        apply_nearby_ride_event(
+            &mut requests,
+            "ride.requested",
+            &nearby_ride_request_json(7),
+        );
+
+        assert_eq!(requests.len(), 1);
+    }
+
+    #[test]
+    fn apply_nearby_ride_event_removes_on_ride_unavailable() {
+        let mut requests = Vec::new();
+        apply_nearby_ride_event(
+            &mut requests,
+            "ride.requested",
+            &nearby_ride_request_json(7),
+        );
+        apply_nearby_ride_event(
+            &mut requests,
+            "ride.requested",
+            &nearby_ride_request_json(9),
+        );
+
+        apply_nearby_ride_event(&mut requests, "ride.unavailable", r#"{"ride_id": 7}"#);
+
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].ride_id, 9);
+    }
+
+    #[test]
+    fn apply_nearby_ride_event_ignores_an_unknown_event_name() {
+        let mut requests = Vec::new();
+
+        apply_nearby_ride_event(&mut requests, "pusher_internal:subscription_succeeded", "");
+
+        assert!(requests.is_empty());
+    }
+
+    #[test]
+    fn apply_nearby_ride_event_ignores_malformed_data_without_panicking() {
+        let mut requests = Vec::new();
+
+        apply_nearby_ride_event(&mut requests, "ride.requested", "not json at all");
+        apply_nearby_ride_event(&mut requests, "ride.unavailable", "not json at all");
+
+        assert!(requests.is_empty());
     }
 }

--- a/crates/moto_core/src/realtime.rs
+++ b/crates/moto_core/src/realtime.rs
@@ -113,6 +113,84 @@ impl std::fmt::Display for SubscribeError {
 
 impl std::error::Error for SubscribeError {}
 
+/// Que hacer en la siguiente vuelta del loop de sondeo de un caller que
+/// consume `RealtimeClient::poll_events()` (p.ej. `NearbyRidesList`,
+/// `moto_ui`, issue #16), decidido puramente a partir del `ConnectionState`
+/// actual y de si ya hay una suscripcion vigente. `subscribed` es el nuevo
+/// valor que el caller debe guardar para la proxima vuelta: se resetea a
+/// `false` cada vez que se sale de `Connected`, porque una reconexion
+/// invalida cualquier suscripcion previa (el servidor no la recuerda tras
+/// un socket nuevo).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PollDecision {
+    pub action: PollAction,
+    pub subscribed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PollAction {
+    /// Seguir esperando: ya esta suscripto y conectado, o el handshake
+    /// todavia esta en curso.
+    Wait,
+    /// Llamar `RealtimeClient::subscribe(token, channel)`.
+    Subscribe,
+    /// Llamar `RealtimeClient::reconnect()` — el transporte no reconecta
+    /// solo (ver doc comment de `reconnect()`).
+    Reconnect,
+}
+
+pub fn decide_poll_action(state: &ConnectionState, subscribed: bool) -> PollDecision {
+    match state {
+        ConnectionState::Connected if subscribed => PollDecision {
+            action: PollAction::Wait,
+            subscribed: true,
+        },
+        ConnectionState::Connected => PollDecision {
+            action: PollAction::Subscribe,
+            subscribed: false,
+        },
+        ConnectionState::Connecting => PollDecision {
+            action: PollAction::Wait,
+            subscribed: false,
+        },
+        ConnectionState::Reconnecting { .. } => PollDecision {
+            action: PollAction::Reconnect,
+            subscribed: false,
+        },
+    }
+}
+
+/// Que hacer cuando `RealtimeClient::subscribe()` devuelve un error, decidido
+/// puramente a partir de la variante de `SubscribeError`.
+///
+/// `POST /api/v1/broadcasting/auth` nunca reintenta con refresh de token
+/// (ver doc comment de `ApiClient::authenticate_broadcast_channel`): un
+/// fallo de auth es deterministico y va a repetirse igual en cada vuelta
+/// del loop con el mismo token, asi que el caller debe cortarlo en vez de
+/// reintentar sin backoff cada vuelta. `Unauthorized` ademas implica que la
+/// sesion ya no es valida en absoluto.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscribeFailureAction {
+    /// Fallo transitorio (el handshake todavia no llego): reintentar en la
+    /// siguiente vuelta del loop.
+    Retry,
+    /// La sesion ya no es valida: hacer logout y cortar el loop.
+    LogoutAndStop,
+    /// Fallo determinístico e irrecuperable que no es cuestion de sesion:
+    /// cortar el loop sin logout.
+    Stop,
+}
+
+pub fn decide_subscribe_failure(error: &SubscribeError) -> SubscribeFailureAction {
+    match error {
+        SubscribeError::NotConnected => SubscribeFailureAction::Retry,
+        SubscribeError::Auth(BroadcastAuthError::Unauthorized) => {
+            SubscribeFailureAction::LogoutAndStop
+        }
+        SubscribeError::Auth(_) => SubscribeFailureAction::Stop,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct PusherFrame {
     event: String,
@@ -534,5 +612,68 @@ mod tests {
 
         assert_eq!(client.state(), ConnectionState::Connecting);
         assert_eq!(client.socket_id(), None);
+    }
+
+    #[test]
+    fn decide_poll_action_subscribes_when_connected_and_not_subscribed_yet() {
+        let decision = decide_poll_action(&ConnectionState::Connected, false);
+
+        assert_eq!(decision.action, PollAction::Subscribe);
+        assert!(!decision.subscribed);
+    }
+
+    #[test]
+    fn decide_poll_action_waits_when_connected_and_already_subscribed() {
+        let decision = decide_poll_action(&ConnectionState::Connected, true);
+
+        assert_eq!(decision.action, PollAction::Wait);
+        assert!(decision.subscribed);
+    }
+
+    #[test]
+    fn decide_poll_action_waits_while_connecting_and_clears_subscribed() {
+        let decision = decide_poll_action(&ConnectionState::Connecting, true);
+
+        assert_eq!(decision.action, PollAction::Wait);
+        assert!(!decision.subscribed);
+    }
+
+    #[test]
+    fn decide_poll_action_reconnects_while_reconnecting_and_clears_subscribed() {
+        let decision = decide_poll_action(&ConnectionState::Reconnecting { attempt: 3 }, true);
+
+        assert_eq!(decision.action, PollAction::Reconnect);
+        assert!(!decision.subscribed);
+    }
+
+    #[test]
+    fn decide_subscribe_failure_retries_when_not_connected_yet() {
+        let action = decide_subscribe_failure(&SubscribeError::NotConnected);
+
+        assert_eq!(action, SubscribeFailureAction::Retry);
+    }
+
+    #[test]
+    fn decide_subscribe_failure_logs_out_and_stops_when_unauthorized() {
+        let action =
+            decide_subscribe_failure(&SubscribeError::Auth(BroadcastAuthError::Unauthorized));
+
+        assert_eq!(action, SubscribeFailureAction::LogoutAndStop);
+    }
+
+    #[test]
+    fn decide_subscribe_failure_stops_without_logout_when_forbidden() {
+        let action = decide_subscribe_failure(&SubscribeError::Auth(BroadcastAuthError::Forbidden));
+
+        assert_eq!(action, SubscribeFailureAction::Stop);
+    }
+
+    #[test]
+    fn decide_subscribe_failure_stops_without_logout_on_network_error() {
+        let action = decide_subscribe_failure(&SubscribeError::Auth(BroadcastAuthError::Network(
+            "boom".to_string(),
+        )));
+
+        assert_eq!(action, SubscribeFailureAction::Stop);
     }
 }

--- a/crates/moto_core/src/realtime.rs
+++ b/crates/moto_core/src/realtime.rs
@@ -49,6 +49,21 @@ impl WsTransport for EwebsockTransport {
     }
 }
 
+/// URL del servidor Reverb (p.ej. `wss://host/app/{key}`), inyectada por el
+/// binario de plataforma (`web`/`mobile`) via contexto de Dioxus, igual que
+/// `ApiClient` (ver `.claude/STANDARDS.md`). A diferencia de la URL base de
+/// la API, esta URL incluye la app key de Reverb, que es un secreto por
+/// entorno sin valor por defecto (`REVERB_APP_KEY` en el `.env.example` de
+/// `Back_App_MotoCarros`) — por eso no hay un fallback de desarrollo local
+/// hardcodeado como con `MOTOYA_API_BASE_URL`. `ws_url` es `None` cuando el
+/// entorno no configuro `MOTOYA_WS_URL`; las pantallas que dependan de
+/// tiempo real (issue #16 y siguientes) deben mostrar un estado explicito en
+/// vez de intentar conectar.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RealtimeConfig {
+    pub ws_url: Option<String>,
+}
+
 /// Estado de la conexion de WebSocket con Reverb.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ConnectionState {

--- a/crates/moto_ui/Cargo.toml
+++ b/crates/moto_ui/Cargo.toml
@@ -5,6 +5,16 @@ edition.workspace = true
 
 [dependencies]
 dioxus = { workspace = true }
+# `futures-timer` da el intervalo de polling de `NearbyRidesScreen` (issue #16)
+# sin recurrir a `#[cfg(target_arch = "wasm32")]` disperso en el codigo: la
+# feature `wasm-bindgen` (que activa el temporizador del navegador via
+# `gloo-timers`) se activa solo para ese target aca, centralizado en el
+# manifiesto — en el resto de targets usa el temporizador nativo por
+# defecto de la crate.
+futures-timer = "3.0.4"
 moto_core = { path = "../moto_core" }
 serde.workspace = true
 serde_json.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+futures-timer = { version = "3.0.4", features = ["wasm-bindgen"] }

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -11,6 +11,7 @@ pub mod screens;
 
 pub use map::{MapMarker, MapView};
 pub use screens::login::LoginScreen;
+pub use screens::nearby_rides::NearbyRidesScreen;
 pub use screens::profile::ProfileScreen;
 pub use screens::register_driver::RegisterDriverScreen;
 pub use screens::register_passenger::RegisterPassengerScreen;
@@ -82,6 +83,7 @@ enum HomeSection {
     Profile,
     RideEstimate,
     Vehicle,
+    NearbyRides,
 }
 
 /// Pantalla principal tras iniciar sesion: perfil (issue #9), tarifa
@@ -89,10 +91,11 @@ enum HomeSection {
 /// seccion — cerrar sesion debe estar disponible desde el momento en que hay
 /// una sesion iniciada.
 ///
-/// La seccion de vehiculo (issues #11 y #12, `VehicleScreen`) solo se ofrece
+/// Las secciones de vehiculo (issues #11 y #12, `VehicleScreen`) y de
+/// solicitudes cercanas (issue #16, `NearbyRidesScreen`) solo se ofrecen
 /// cuando `session.user()` ya cargo (`GET /api/v1/me`, issue #9) y es una
-/// cuenta de conductor: un pasajero nunca ve el boton, y estructuralmente no
-/// puede llegar a esa pantalla desde esta navegacion.
+/// cuenta de conductor: un pasajero nunca ve esos botones, y
+/// estructuralmente no puede llegar a esas pantallas desde esta navegacion.
 #[component]
 fn Home() -> Element {
     let api_client = use_context::<ApiClient>();
@@ -148,6 +151,12 @@ fn Home() -> Element {
                         onclick: move |_| section.set(HomeSection::Vehicle),
                         "Mi vehiculo"
                     }
+                    button {
+                        r#type: "button",
+                        disabled: section() == HomeSection::NearbyRides,
+                        onclick: move |_| section.set(HomeSection::NearbyRides),
+                        "Solicitudes cercanas"
+                    }
                 }
             }
             match section() {
@@ -159,6 +168,9 @@ fn Home() -> Element {
                 },
                 HomeSection::Vehicle => rsx! {
                     VehicleScreen {}
+                },
+                HomeSection::NearbyRides => rsx! {
+                    NearbyRidesScreen {}
                 },
             }
             button {

--- a/crates/moto_ui/src/screens/mod.rs
+++ b/crates/moto_ui/src/screens/mod.rs
@@ -1,4 +1,5 @@
 pub mod login;
+pub mod nearby_rides;
 pub mod profile;
 pub mod register_driver;
 pub mod register_passenger;

--- a/crates/moto_ui/src/screens/nearby_rides.rs
+++ b/crates/moto_ui/src/screens/nearby_rides.rs
@@ -22,9 +22,9 @@ use std::time::Duration;
 
 use dioxus::prelude::*;
 use futures_timer::Delay;
-use moto_core::api::{ApiClient, AuthenticatedRequestError, GetVehicleError};
+use moto_core::api::{ApiClient, AuthenticatedRequestError, BroadcastAuthError, GetVehicleError};
 use moto_core::models::{NearbyRideRequest, RideNoLongerAvailable};
-use moto_core::realtime::{ConnectionState, RealtimeClient, RealtimeConfig};
+use moto_core::realtime::{ConnectionState, RealtimeClient, RealtimeConfig, SubscribeError};
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
 
@@ -153,7 +153,8 @@ struct NearbyRidesListProps {
 #[component]
 fn NearbyRidesList(props: NearbyRidesListProps) -> Element {
     let api_client = use_context::<ApiClient>();
-    let session = use_context::<SessionState>();
+    let mut session = use_context::<SessionState>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
     let realtime_config = use_context::<RealtimeConfig>();
 
     let mut status = use_signal(|| RealtimeStatus::Connecting);
@@ -184,6 +185,7 @@ fn NearbyRidesList(props: NearbyRidesListProps) -> Element {
         };
 
         let api_client = api_client.clone();
+        let storage = storage.clone();
         let bare_channel = format!("driver.{}", props.driver_id);
         let full_channel = format!("private-{bare_channel}");
 
@@ -234,7 +236,25 @@ fn NearbyRidesList(props: NearbyRidesListProps) -> Element {
                                 subscribed = true;
                                 status.set(RealtimeStatus::Connected);
                             }
-                            Err(err) => {
+                            // `POST /api/v1/broadcasting/auth` nunca reintenta
+                            // con refresh de token (ver doc comment de
+                            // `broadcast_auth` en `moto_core::api`): un fallo
+                            // de auth aqui es determinístico y va a repetirse
+                            // en cada vuelta del loop con el mismo token, asi
+                            // que se corta en vez de reintentar sin backoff
+                            // cada `POLL_INTERVAL`. `Unauthorized` ademas
+                            // implica que la sesion ya no es valida en
+                            // absoluto, igual que `SessionExpired` mas arriba.
+                            Err(SubscribeError::Auth(auth_err)) => {
+                                let unauthorized =
+                                    matches!(auth_err, BroadcastAuthError::Unauthorized);
+                                status.set(RealtimeStatus::Unavailable(auth_err.to_string()));
+                                if unauthorized {
+                                    session.logout(storage.as_ref());
+                                }
+                                break;
+                            }
+                            Err(err @ SubscribeError::NotConnected) => {
                                 status.set(RealtimeStatus::Unavailable(err.to_string()));
                             }
                         }

--- a/crates/moto_ui/src/screens/nearby_rides.rs
+++ b/crates/moto_ui/src/screens/nearby_rides.rs
@@ -12,9 +12,10 @@
 //! `ride.requested` (agrega una solicitud a la lista) y `ride.unavailable`
 //! (otro conductor la acepto primero, se quita de la lista). El transporte
 //! de tiempo real no reconecta ni resuscribe solo (ver
-//! `RealtimeClient`), asi que esta pantalla lo hace por su cuenta: sondea el
-//! estado de la conexion y vuelve a suscribirse cada vez que pasa a
-//! `Connected` sin una suscripcion vigente.
+//! `RealtimeClient`), asi que esta pantalla lo hace por su cuenta: llama
+//! `reconnect()` explicitamente cada vez que el estado pasa a
+//! `Reconnecting` y vuelve a suscribirse cada vez que pasa a `Connected`
+//! sin una suscripcion vigente.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -246,6 +247,19 @@ fn NearbyRidesList(props: NearbyRidesListProps) -> Element {
                     ConnectionState::Reconnecting { .. } => {
                         subscribed = false;
                         status.set(RealtimeStatus::Reconnecting);
+                        // `RealtimeClient` no reconecta solo (ver doc comment
+                        // de `reconnect()`): el caller debe reabrir la
+                        // conexion explicitamente. El `Delay` de mas abajo ya
+                        // espacia estos intentos a `POLL_INTERVAL`, asi que no
+                        // hace falta backoff propio. Un fallo aqui suele ser
+                        // la misma URL invalida que fallaria en cada intento
+                        // (igual que el `connect()` inicial de mas arriba),
+                        // asi que se reporta como no disponible y se corta el
+                        // loop en vez de reintentar para siempre.
+                        if let Err(err) = client.reconnect() {
+                            status.set(RealtimeStatus::Unavailable(err));
+                            break;
+                        }
                     }
                 }
 

--- a/crates/moto_ui/src/screens/nearby_rides.rs
+++ b/crates/moto_ui/src/screens/nearby_rides.rs
@@ -1,0 +1,292 @@
+//! Pantalla de solicitudes de viaje cercanas (conductor) — issue #16.
+//!
+//! Al entrar, primero valida que el conductor ya tenga un vehiculo
+//! registrado con `GET /api/v1/me/vehicle` — mismo criterio y mismo 404
+//! (`GetVehicleError::NotFound`) que usa `VehicleScreen` (issues #11/#12)
+//! para decidir si redirige al registro. Un conductor sin vehiculo nunca
+//! llega a ver la lista.
+//!
+//! Con vehiculo confirmado, se suscribe al canal privado `driver.{id}` de
+//! Reverb (`id` = `User.id`, ver `moto_core::realtime::RealtimeClient`) y
+//! escucha dos eventos, documentados por el backend en el propio issue:
+//! `ride.requested` (agrega una solicitud a la lista) y `ride.unavailable`
+//! (otro conductor la acepto primero, se quita de la lista). El transporte
+//! de tiempo real no reconecta ni resuscribe solo (ver
+//! `RealtimeClient`), asi que esta pantalla lo hace por su cuenta: sondea el
+//! estado de la conexion y vuelve a suscribirse cada vez que pasa a
+//! `Connected` sin una suscripcion vigente.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use dioxus::prelude::*;
+use futures_timer::Delay;
+use moto_core::api::{ApiClient, AuthenticatedRequestError, GetVehicleError};
+use moto_core::models::{NearbyRideRequest, RideNoLongerAvailable};
+use moto_core::realtime::{ConnectionState, RealtimeClient, RealtimeConfig};
+use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
+
+use super::register_vehicle::RegisterVehicleScreen;
+
+/// Intervalo entre sondeos de `RealtimeClient::poll_events` — no hay forma de
+/// que el transporte avise por si solo cuando llega un frame nuevo (ver
+/// `.claude/STANDARDS.md`, el crate no tiene runtime propio), asi que la
+/// pantalla lo consulta activamente a este ritmo.
+const POLL_INTERVAL: Duration = Duration::from_millis(700);
+
+#[component]
+pub fn NearbyRidesScreen() -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut is_loading = use_signal(|| false);
+    let mut load_error = use_signal(|| None::<String>);
+    let mut not_registered = use_signal(|| false);
+    let mut driver_id = use_signal(|| None::<u64>);
+    // Misma guarda que `VehicleScreen`/`ProfileScreen`: el efecto lee
+    // `session.token()` en su primera corrida, lo que lo suscribe a ese
+    // signal, y el fetch puede terminar escribiendo en `session` (refresh de
+    // token, logout) — sin esta bandera reprogramaria el efecto en un loop.
+    let mut has_fetched = use_signal(|| false);
+
+    use_effect(move || {
+        if has_fetched() {
+            return;
+        }
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        has_fetched.set(true);
+
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            load_error.set(None);
+
+            // `GET /me` primero: esta pantalla necesita el id de cuenta para
+            // el canal `driver.{id}`, y no se puede asumir que `ProfileScreen`
+            // (issue #9) ya corrio antes en esta sesion — `Home` solo ofrece
+            // esta pestana a conductores, pero eso no obliga un orden de
+            // navegacion.
+            let token_for_vehicle = match api_client.me(&token).await {
+                Ok(fetch) => {
+                    let mut current_token = token.clone();
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed.clone(), storage.as_ref());
+                        current_token = refreshed;
+                    }
+                    driver_id.set(Some(fetch.data.id));
+                    session.set_user(fetch.data);
+                    current_token
+                }
+                Err(AuthenticatedRequestError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                    is_loading.set(false);
+                    return;
+                }
+                Err(err) => {
+                    load_error.set(Some(err.to_string()));
+                    is_loading.set(false);
+                    return;
+                }
+            };
+
+            match api_client.get_vehicle(&token_for_vehicle).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                }
+                Err(GetVehicleError::NotFound) => {
+                    not_registered.set(true);
+                }
+                Err(GetVehicleError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    load_error.set(Some(err.to_string()));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    });
+
+    rsx! {
+        if not_registered() {
+            RegisterVehicleScreen {}
+        } else if is_loading() {
+            div { class: "nearby-rides-screen", p { "Cargando..." } }
+        } else if let Some(message) = load_error() {
+            div { class: "nearby-rides-screen",
+                p { class: "nearby-rides-error", role: "alert", "{message}" }
+            }
+        } else if let Some(id) = driver_id() {
+            NearbyRidesList { driver_id: id }
+        }
+    }
+}
+
+/// Estado de la conexion en tiempo real, tal como lo muestra esta pantalla —
+/// distinto de `moto_core::realtime::ConnectionState`: agrega el caso
+/// `Unavailable` (config ausente o error irrecuperable) y no expone el
+/// numero de intento de reconexion, que no le sirve al usuario final.
+#[derive(Debug, Clone, PartialEq)]
+enum RealtimeStatus {
+    Connecting,
+    Connected,
+    Reconnecting,
+    Unavailable(String),
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct NearbyRidesListProps {
+    driver_id: u64,
+}
+
+#[component]
+fn NearbyRidesList(props: NearbyRidesListProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let session = use_context::<SessionState>();
+    let realtime_config = use_context::<RealtimeConfig>();
+
+    let mut status = use_signal(|| RealtimeStatus::Connecting);
+    let mut requests = use_signal(Vec::<NearbyRideRequest>::new);
+    // El loop de sondeo corre para siempre mientras la pantalla este
+    // montada (Dioxus cancela la tarea al desmontar el componente, ver
+    // `Home` en `moto_ui/src/lib.rs`) — esta bandera solo evita levantar un
+    // segundo loop si el efecto se vuelve a disparar.
+    let mut started = use_signal(|| false);
+
+    use_effect(move || {
+        if started() {
+            return;
+        }
+        started.set(true);
+
+        let Some(ws_url) = realtime_config.ws_url.clone() else {
+            status.set(RealtimeStatus::Unavailable(
+                "El tiempo real no esta configurado en este entorno.".to_string(),
+            ));
+            return;
+        };
+        let Some(token) = session.token() else {
+            status.set(RealtimeStatus::Unavailable(
+                "La sesion expiro. Inicia sesion de nuevo.".to_string(),
+            ));
+            return;
+        };
+
+        let api_client = api_client.clone();
+        let bare_channel = format!("driver.{}", props.driver_id);
+        let full_channel = format!("private-{bare_channel}");
+
+        spawn(async move {
+            let mut client = match RealtimeClient::connect(api_client, ws_url) {
+                Ok(client) => client,
+                Err(err) => {
+                    status.set(RealtimeStatus::Unavailable(err));
+                    return;
+                }
+            };
+            let mut subscribed = false;
+
+            loop {
+                for event in client.poll_events() {
+                    if event.channel != full_channel {
+                        continue;
+                    }
+                    match event.event.as_str() {
+                        "ride.requested" => {
+                            if let Ok(request) =
+                                serde_json::from_str::<NearbyRideRequest>(&event.data)
+                            {
+                                requests.with_mut(|list| {
+                                    if !list.iter().any(|r| r.ride_id == request.ride_id) {
+                                        list.push(request);
+                                    }
+                                });
+                            }
+                        }
+                        "ride.unavailable" => {
+                            if let Ok(gone) =
+                                serde_json::from_str::<RideNoLongerAvailable>(&event.data)
+                            {
+                                requests.with_mut(|list| {
+                                    list.retain(|r| r.ride_id != gone.ride_id);
+                                });
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                match client.state() {
+                    ConnectionState::Connected if !subscribed => {
+                        match client.subscribe(&token, &bare_channel).await {
+                            Ok(()) => {
+                                subscribed = true;
+                                status.set(RealtimeStatus::Connected);
+                            }
+                            Err(err) => {
+                                status.set(RealtimeStatus::Unavailable(err.to_string()));
+                            }
+                        }
+                    }
+                    ConnectionState::Connected => {}
+                    ConnectionState::Connecting => {
+                        subscribed = false;
+                        status.set(RealtimeStatus::Connecting);
+                    }
+                    ConnectionState::Reconnecting { .. } => {
+                        subscribed = false;
+                        status.set(RealtimeStatus::Reconnecting);
+                    }
+                }
+
+                Delay::new(POLL_INTERVAL).await;
+            }
+        });
+    });
+
+    rsx! {
+        div { class: "nearby-rides-screen",
+            h2 { "Solicitudes cercanas" }
+            match status() {
+                RealtimeStatus::Connecting => rsx! {
+                    p { "Conectando..." }
+                },
+                RealtimeStatus::Reconnecting => rsx! {
+                    p { "Reconectando..." }
+                },
+                RealtimeStatus::Unavailable(message) => rsx! {
+                    p { class: "nearby-rides-error", role: "alert", "{message}" }
+                },
+                RealtimeStatus::Connected => rsx! {
+                    if requests().is_empty() {
+                        p { class: "nearby-rides-empty", "No hay solicitudes disponibles por el momento." }
+                    } else {
+                        ul { class: "nearby-rides-list",
+                            for request in requests() {
+                                li { key: "{request.ride_id}", class: "nearby-ride-request",
+                                    p {
+                                        "Origen: {request.origin.latitude}, {request.origin.longitude}"
+                                    }
+                                    p {
+                                        "Destino: {request.destination.latitude}, {request.destination.longitude}"
+                                    }
+                                    p { "Tarifa estimada: {request.currency} {request.estimated_fare}" }
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    }
+}

--- a/crates/moto_ui/src/screens/nearby_rides.rs
+++ b/crates/moto_ui/src/screens/nearby_rides.rs
@@ -11,20 +11,25 @@
 //! escucha dos eventos, documentados por el backend en el propio issue:
 //! `ride.requested` (agrega una solicitud a la lista) y `ride.unavailable`
 //! (otro conductor la acepto primero, se quita de la lista). El transporte
-//! de tiempo real no reconecta ni resuscribe solo (ver
-//! `RealtimeClient`), asi que esta pantalla lo hace por su cuenta: llama
-//! `reconnect()` explicitamente cada vez que el estado pasa a
-//! `Reconnecting` y vuelve a suscribirse cada vez que pasa a `Connected`
-//! sin una suscripcion vigente.
+//! de tiempo real no reconecta ni resuscribe solo (ver `RealtimeClient`),
+//! asi que esta pantalla lo hace por su cuenta en cada vuelta de su loop de
+//! sondeo — pero la decision de *cuando* suscribirse, reconectar o cortar
+//! el loop, y el dedup de eventos por `ride_id`, vive en
+//! `moto_core::realtime` (`decide_poll_action`, `decide_subscribe_failure`)
+//! y `moto_core::models` (`apply_nearby_ride_event`): logica pura y
+//! testeada ahi, no en este componente Dioxus.
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use dioxus::prelude::*;
 use futures_timer::Delay;
-use moto_core::api::{ApiClient, AuthenticatedRequestError, BroadcastAuthError, GetVehicleError};
-use moto_core::models::{NearbyRideRequest, RideNoLongerAvailable};
-use moto_core::realtime::{ConnectionState, RealtimeClient, RealtimeConfig, SubscribeError};
+use moto_core::api::{ApiClient, AuthenticatedRequestError, GetVehicleError};
+use moto_core::models::{NearbyRideRequest, apply_nearby_ride_event};
+use moto_core::realtime::{
+    ConnectionState, PollAction, RealtimeClient, RealtimeConfig, SubscribeFailureAction,
+    decide_poll_action, decide_subscribe_failure,
+};
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
 
@@ -204,78 +209,57 @@ fn NearbyRidesList(props: NearbyRidesListProps) -> Element {
                     if event.channel != full_channel {
                         continue;
                     }
-                    match event.event.as_str() {
-                        "ride.requested" => {
-                            if let Ok(request) =
-                                serde_json::from_str::<NearbyRideRequest>(&event.data)
-                            {
-                                requests.with_mut(|list| {
-                                    if !list.iter().any(|r| r.ride_id == request.ride_id) {
-                                        list.push(request);
-                                    }
-                                });
-                            }
-                        }
-                        "ride.unavailable" => {
-                            if let Ok(gone) =
-                                serde_json::from_str::<RideNoLongerAvailable>(&event.data)
-                            {
-                                requests.with_mut(|list| {
-                                    list.retain(|r| r.ride_id != gone.ride_id);
-                                });
-                            }
-                        }
-                        _ => {}
-                    }
+                    requests.with_mut(|list| {
+                        apply_nearby_ride_event(list, &event.event, &event.data);
+                    });
                 }
 
-                match client.state() {
-                    ConnectionState::Connected if !subscribed => {
-                        match client.subscribe(&token, &bare_channel).await {
-                            Ok(()) => {
-                                subscribed = true;
-                                status.set(RealtimeStatus::Connected);
-                            }
-                            // `POST /api/v1/broadcasting/auth` nunca reintenta
-                            // con refresh de token (ver doc comment de
-                            // `broadcast_auth` en `moto_core::api`): un fallo
-                            // de auth aqui es determinístico y va a repetirse
-                            // en cada vuelta del loop con el mismo token, asi
-                            // que se corta en vez de reintentar sin backoff
-                            // cada `POLL_INTERVAL`. `Unauthorized` ademas
-                            // implica que la sesion ya no es valida en
-                            // absoluto, igual que `SessionExpired` mas arriba.
-                            Err(SubscribeError::Auth(auth_err)) => {
-                                let unauthorized =
-                                    matches!(auth_err, BroadcastAuthError::Unauthorized);
-                                status.set(RealtimeStatus::Unavailable(auth_err.to_string()));
-                                if unauthorized {
-                                    session.logout(storage.as_ref());
-                                }
-                                break;
-                            }
-                            Err(err @ SubscribeError::NotConnected) => {
-                                status.set(RealtimeStatus::Unavailable(err.to_string()));
-                            }
-                        }
+                // La decision de cuando suscribirse/reconectar/cortar el
+                // loop vive en `moto_core::realtime` (`decide_poll_action`,
+                // `decide_subscribe_failure`) para poder testearla sin
+                // Dioxus ni un socket real — este bloque solo ejecuta esa
+                // decision y actualiza el estado visible.
+                let state = client.state();
+                match &state {
+                    ConnectionState::Connecting => status.set(RealtimeStatus::Connecting),
+                    ConnectionState::Reconnecting { .. } => {
+                        status.set(RealtimeStatus::Reconnecting)
                     }
                     ConnectionState::Connected => {}
-                    ConnectionState::Connecting => {
-                        subscribed = false;
-                        status.set(RealtimeStatus::Connecting);
-                    }
-                    ConnectionState::Reconnecting { .. } => {
-                        subscribed = false;
-                        status.set(RealtimeStatus::Reconnecting);
-                        // `RealtimeClient` no reconecta solo (ver doc comment
-                        // de `reconnect()`): el caller debe reabrir la
-                        // conexion explicitamente. El `Delay` de mas abajo ya
-                        // espacia estos intentos a `POLL_INTERVAL`, asi que no
-                        // hace falta backoff propio. Un fallo aqui suele ser
-                        // la misma URL invalida que fallaria en cada intento
-                        // (igual que el `connect()` inicial de mas arriba),
-                        // asi que se reporta como no disponible y se corta el
-                        // loop en vez de reintentar para siempre.
+                }
+
+                let decision = decide_poll_action(&state, subscribed);
+                subscribed = decision.subscribed;
+
+                match decision.action {
+                    PollAction::Wait => {}
+                    PollAction::Subscribe => match client.subscribe(&token, &bare_channel).await {
+                        Ok(()) => {
+                            subscribed = true;
+                            status.set(RealtimeStatus::Connected);
+                        }
+                        Err(err) => {
+                            status.set(RealtimeStatus::Unavailable(err.to_string()));
+                            match decide_subscribe_failure(&err) {
+                                SubscribeFailureAction::Retry => {}
+                                SubscribeFailureAction::LogoutAndStop => {
+                                    session.logout(storage.as_ref());
+                                    break;
+                                }
+                                SubscribeFailureAction::Stop => break,
+                            }
+                        }
+                    },
+                    // `RealtimeClient` no reconecta solo (ver doc comment de
+                    // `reconnect()`): el caller debe reabrir la conexion
+                    // explicitamente. El `Delay` de mas abajo ya espacia
+                    // estos intentos a `POLL_INTERVAL`, asi que no hace
+                    // falta backoff propio. Un fallo aqui suele ser la misma
+                    // URL invalida que fallaria en cada intento (igual que
+                    // el `connect()` inicial de mas arriba), asi que se
+                    // reporta como no disponible y se corta el loop en vez
+                    // de reintentar para siempre.
+                    PollAction::Reconnect => {
                         if let Err(err) = client.reconnect() {
                             status.set(RealtimeStatus::Unavailable(err));
                             break;

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use dioxus::prelude::*;
 use moto_core::api::ApiClient;
+use moto_core::realtime::RealtimeConfig;
 use moto_core::storage::TokenStorage;
 use moto_ui::App;
 
@@ -18,9 +19,19 @@ fn main() {
     let base_url = option_env!("MOTOYA_API_BASE_URL")
         .unwrap_or(DEFAULT_API_BASE_URL)
         .to_string();
+    // Sin fallback de desarrollo local a proposito: la URL incluye la app key
+    // de Reverb, un secreto por entorno sin valor por defecto (ver
+    // `RealtimeConfig`). `None` hasta que el entorno configure
+    // `MOTOYA_WS_URL`.
+    let ws_url = option_env!("MOTOYA_WS_URL").map(str::to_string);
 
     LaunchBuilder::new()
         .with_context_provider(move || Box::new(ApiClient::new(base_url.clone())))
+        .with_context_provider(move || {
+            Box::new(RealtimeConfig {
+                ws_url: ws_url.clone(),
+            })
+        })
         .with_context_provider(|| {
             Box::new(Arc::new(WebTokenStorage::new()) as Arc<dyn TokenStorage>)
         })


### PR DESCRIPTION
Closes #16

## Qué hace

Pantalla `NearbyRidesScreen` (nueva pestaña "Solicitudes cercanas" en `Home`,
visible solo para conductores) que:

- Al entrar, valida con `GET /api/v1/me/vehicle` que el conductor ya tenga un
  vehículo registrado (mismo criterio de 404 que ya usa `VehicleScreen`,
  issues #11/#12) — sin vehículo, redirige a `RegisterVehicleScreen` en vez de
  mostrar la lista.
- Con vehículo confirmado, abre una conexión de tiempo real
  (`moto_core::realtime::RealtimeClient`, issue #5) y se suscribe al canal
  privado `driver.{id}` (`id` = `User.id`), documentado en los comentarios del
  propio issue #16 contra `Back_App_MotoCarros`.
- Escucha `ride.requested` (agrega la solicitud a la lista) y
  `ride.unavailable` (otro conductor la aceptó primero, se quita de la
  lista).
- Muestra un estado explícito de conexión (conectando/reconectando/no
  disponible) y un estado vacío explícito cuando no hay solicitudes, en vez
  de una pantalla en blanco (tercer criterio de aceptación).

## Decisiones y riesgos

- **`RealtimeClient` no traía ningún consumidor en la UI todavía** (solo
  tenía tests unitarios en `moto_core`, issue #5). Esta historia es la
  primera en conectarlo: la pantalla misma sondea `poll_events()` en un loop
  (no hay forma de que el transporte avise por sí solo) y se re-suscribe cada
  vez que la conexión pasa a `Connected` sin suscripción vigente, cubriendo
  reconexiones.
- **Nueva dependencia cross-platform: `futures-timer`.** El loop de sondeo
  necesita dormir entre iteraciones sin bloquear el hilo, y ni `moto_core` ni
  `moto_ui` tenían un temporizador que compile tanto en `wasm32-unknown-unknown`
  como en nativo sin `#[cfg(target_arch = "wasm32")]` disperso en el código
  (`tokio` es solo dev-dependency de tests, y no soporta timers en wasm).
  `futures-timer` resuelve esto con una sola declaración centralizada en
  `crates/moto_ui/Cargo.toml` (`[target.'cfg(target_arch = "wasm32")'.dependencies]`
  activando su feature `wasm-bindgen`), sin cfg disperso en `nearby_rides.rs`.
  Validado con `cargo build --package web --target wasm32-unknown-unknown`
  (mismo comando que corre el job `build-web` del CI) y con `cargo check -p mobile`
  en nativo — ambos compilan limpio.
- **Nuevo `RealtimeConfig` inyectado por contexto** (`ws_url: Option<String>`),
  wireado en `web/main.rs` y `mobile/main.rs` vía `MOTOYA_WS_URL`. A
  diferencia de `MOTOYA_API_BASE_URL`, **no tiene fallback de desarrollo local
  hardcodeado**: la URL de Reverb incluye la app key, que es un secreto por
  entorno sin default (`REVERB_APP_KEY` en el `.env.example` de
  `Back_App_MotoCarros`). Si el entorno no configura `MOTOYA_WS_URL`, la
  pantalla lo trata como un estado "no disponible" explícito en vez de
  intentar conectar con una URL inventada.
- **La pantalla hace su propio `GET /me`** (además de `GET /me/vehicle`) para
  obtener el `id` de cuenta que arma el canal `driver.{id}`, en vez de asumir
  que `ProfileScreen` (issue #9) ya corrió antes en esta sesión — `Home` solo
  oculta el botón a pasajeros, no garantiza un orden de navegación.
- **Fuera de alcance a propósito:** el toggle de "marcarme disponible"
  (`PATCH /api/v1/me/availability` ya existe en el backend) no tiene ninguna
  historia de UI creada todavía en este repo. El criterio de aceptación de
  #16 solo describe esa disponibilidad como precondición de la pantalla, no
  pide implementar el toggle — lo dejo así para no meter scope creep; puede
  ameritar un issue aparte.

## Cómo se probó

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude mobile` (dos tests nuevos en
  `moto_core::models` para `NearbyRideRequest`/`RideNoLongerAvailable`; el
  resto de la lógica nueva vive en `moto_ui` sin tests automatizados, igual
  que el resto de las pantallas — ver `.claude/STANDARDS.md`, "el renderizado
  real en web/mobile no se testea en CI, se valida manualmente")
- `cargo build --package web --target wasm32-unknown-unknown` (mismo comando
  que el job `build-web` del CI)
- `cargo check -p mobile` en nativo, best-effort (no lo exige el CI, pero
  comparte `moto_ui`)
- No pude validar manualmente en navegador/emulador contra un backend con
  Reverb corriendo de verdad (fuera del alcance de este entorno de
  ejecución) — queda pendiente de validación manual antes de mergear, tal
  como pide `.claude/STANDARDS.md` para el renderizado real.