### PR TITLE
feat(#17): aceptar una solicitud de viaje disponible

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -665,6 +665,58 @@ impl std::fmt::Display for CancelRideError {
 
 impl std::error::Error for CancelRideError {}
 
+/// Fallos posibles de `POST /api/v1/rides/{ride}/accept` (issue #17).
+///
+/// `Conflict` (409) es la carrera documentada en `openapi.yaml`: dos
+/// conductores intentan aceptar el mismo viaje casi al mismo tiempo, y el que
+/// llega segundo recibe este error en vez de uno generico — el caller lo usa
+/// para sacar la solicitud de la lista con un mensaje explicito en vez de un
+/// error de servidor. `Validation` cubre en cambio que el conductor
+/// autenticado ya tenga un viaje propio activo (`accepted` o `in_progress`):
+/// tiene permiso para aceptar, pero no puede mientras no libere el que ya
+/// tiene.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AcceptRideError {
+    /// La cuenta autenticada no es de un conductor.
+    Forbidden,
+    /// No existe ningun viaje con ese id.
+    NotFound,
+    /// El viaje ya no esta disponible: otro conductor lo acepto primero, o
+    /// cambio de estado por otro motivo.
+    Conflict,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for AcceptRideError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcceptRideError::Forbidden => {
+                write!(f, "Esta cuenta no puede aceptar viajes.")
+            }
+            AcceptRideError::NotFound => write!(f, "El viaje ya no existe."),
+            AcceptRideError::Conflict => write!(f, "Este viaje ya no esta disponible."),
+            AcceptRideError::Validation(body) => write!(f, "{}", body.message),
+            AcceptRideError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            AcceptRideError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            AcceptRideError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AcceptRideError {}
+
 /// Fallos posibles de `POST /api/v1/broadcasting/auth` (issue #5).
 ///
 /// A diferencia del resto de las requests autenticadas, esta nunca reintenta
@@ -756,6 +808,15 @@ enum CancelRideOutcome {
     Unauthorized,
     Forbidden,
     NotFound,
+    Validation(ApiErrorBody),
+}
+
+enum AcceptRideOutcome {
+    Success(Ride),
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    Conflict,
     Validation(ApiErrorBody),
 }
 
@@ -1778,6 +1839,96 @@ impl ApiClient {
                 Ok(CancelRideOutcome::Validation(body))
             }
             other => Err(CancelRideError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/rides/{ride}/accept` — issue #17. No manda body: como
+    /// `cancel_ride`, todo lo que decide esta operacion es el id del viaje y
+    /// quien la pide. Reintenta una vez con refresh de token ante un 401,
+    /// igual que `cancel_ride`; un 403 (cuenta no conductora), 404 (no
+    /// existe), 409 (otro conductor lo acepto primero) o 422 (el conductor ya
+    /// tiene un viaje propio activo) nunca se reintentan.
+    pub async fn accept_ride(
+        &self,
+        token: &AuthToken,
+        ride_id: u64,
+    ) -> Result<AuthenticatedFetch<Ride>, AcceptRideError> {
+        match self
+            .post_accept_with_token(ride_id, &token.access_token)
+            .await?
+        {
+            AcceptRideOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            AcceptRideOutcome::Forbidden => return Err(AcceptRideError::Forbidden),
+            AcceptRideOutcome::NotFound => return Err(AcceptRideError::NotFound),
+            AcceptRideOutcome::Conflict => return Err(AcceptRideError::Conflict),
+            AcceptRideOutcome::Validation(body) => return Err(AcceptRideError::Validation(body)),
+            AcceptRideOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| AcceptRideError::SessionExpired)?;
+
+        match self
+            .post_accept_with_token(ride_id, &renewed.access_token)
+            .await?
+        {
+            AcceptRideOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            AcceptRideOutcome::Forbidden => Err(AcceptRideError::Forbidden),
+            AcceptRideOutcome::NotFound => Err(AcceptRideError::NotFound),
+            AcceptRideOutcome::Conflict => Err(AcceptRideError::Conflict),
+            AcceptRideOutcome::Validation(body) => Err(AcceptRideError::Validation(body)),
+            AcceptRideOutcome::Unauthorized => Err(AcceptRideError::SessionExpired),
+        }
+    }
+
+    async fn post_accept_with_token(
+        &self,
+        ride_id: u64,
+        access_token: &str,
+    ) -> Result<AcceptRideOutcome, AcceptRideError> {
+        let url = format!("{}/api/v1/rides/{}/accept", self.base_url, ride_id);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|err| AcceptRideError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<Ride> = response
+                .json()
+                .await
+                .map_err(|err| AcceptRideError::Network(err.to_string()))?;
+            return Ok(AcceptRideOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(AcceptRideOutcome::Unauthorized),
+            403 => Ok(AcceptRideOutcome::Forbidden),
+            404 => Ok(AcceptRideOutcome::NotFound),
+            409 => Ok(AcceptRideOutcome::Conflict),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| AcceptRideError::Network(err.to_string()))?;
+                Ok(AcceptRideOutcome::Validation(body))
+            }
+            other => Err(AcceptRideError::Unexpected(other)),
         }
     }
 
@@ -4118,6 +4269,218 @@ mod tests {
         let error = client.cancel_ride(&sample_token(), 1).await.unwrap_err();
 
         assert!(matches!(error, CancelRideError::Network(_)));
+    }
+
+    fn sample_accepted_ride_json() -> serde_json::Value {
+        let mut ride = sample_ride_json();
+        ride["status"] = serde_json::json!("accepted");
+        ride["driver"] = serde_json::json!({"id": 42, "name": "Carlos Perez"});
+        ride
+    }
+
+    #[tokio::test]
+    async fn accept_ride_returns_the_accepted_ride_with_the_assigned_driver() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/accept"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": sample_accepted_ride_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.accept_ride(&sample_token(), 1).await.unwrap();
+
+        assert_eq!(fetch.data.id, 1);
+        assert_eq!(fetch.data.status, crate::models::RideStatus::Accepted);
+        assert_eq!(
+            fetch.data.driver,
+            Some(crate::models::RideDriver {
+                id: 42,
+                name: "Carlos Perez".to_string(),
+            })
+        );
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn accept_ride_returns_forbidden_on_403_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/accept"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.accept_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(error, AcceptRideError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn accept_ride_returns_not_found_on_404_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/999/accept"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "No query results for model [App\\Models\\Ride] 999.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.accept_ride(&sample_token(), 999).await.unwrap_err();
+
+        assert_eq!(error, AcceptRideError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn accept_ride_returns_conflict_on_409_when_another_driver_accepted_first() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/accept"))
+            .respond_with(ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                "message": "Este viaje ya no está disponible.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.accept_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(error, AcceptRideError::Conflict);
+    }
+
+    #[tokio::test]
+    async fn accept_ride_returns_validation_error_on_422_when_the_driver_has_an_active_ride() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/accept"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Ya tienes un viaje activo; terminalo o cancelalo antes de aceptar otro.",
+                "errors": {
+                    "ride": ["Ya tienes un viaje activo; terminalo o cancelalo antes de aceptar otro."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.accept_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(
+            error,
+            AcceptRideError::Validation(ApiErrorBody {
+                message: "Ya tienes un viaje activo; terminalo o cancelalo antes de aceptar otro."
+                    .to_string(),
+                errors: Some(HashMap::from([(
+                    "ride".to_string(),
+                    vec![
+                        "Ya tienes un viaje activo; terminalo o cancelalo antes de aceptar otro."
+                            .to_string()
+                    ]
+                )])),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn accept_ride_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/accept"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/accept"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": sample_accepted_ride_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.accept_ride(&sample_token(), 1).await.unwrap();
+
+        assert_eq!(fetch.data.id, 1);
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn accept_ride_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/accept"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.accept_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(error, AcceptRideError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn accept_ride_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client.accept_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert!(matches!(error, AcceptRideError::Network(_)));
     }
 
     #[tokio::test]

--- a/crates/moto_ui/src/screens/nearby_rides.rs
+++ b/crates/moto_ui/src/screens/nearby_rides.rs
@@ -1,4 +1,4 @@
-//! Pantalla de solicitudes de viaje cercanas (conductor) — issue #16.
+//! Pantalla de solicitudes de viaje cercanas (conductor) — issues #16 y #17.
 //!
 //! Al entrar, primero valida que el conductor ya tenga un vehiculo
 //! registrado con `GET /api/v1/me/vehicle` — mismo criterio y mismo 404
@@ -18,14 +18,25 @@
 //! `moto_core::realtime` (`decide_poll_action`, `decide_subscribe_failure`)
 //! y `moto_core::models` (`apply_nearby_ride_event`): logica pura y
 //! testeada ahi, no en este componente Dioxus.
+//!
+//! Cada solicitud de la lista ofrece un boton "Aceptar" que llama a
+//! `POST /api/v1/rides/{ride}/accept` (`ApiClient::accept_ride`, issue #17).
+//! Al aceptar con exito, la pantalla deja de mostrar la lista y muestra el
+//! viaje aceptado (con conductor asignado) — aceptar un segundo viaje no es
+//! posible mientras el conductor tenga uno activo (`AcceptRideError::Validation`
+//! del backend), asi que no tiene sentido seguir ofreciendo la lista despues.
+//! Si el backend responde 409 (`AcceptRideError::Conflict`, otro conductor lo
+//! acepto primero — carrera documentada en `openapi.yaml`), la solicitud se
+//! saca de la lista con un mensaje explicito en vez de un error generico, tal
+//! como pide el criterio de aceptacion del issue.
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use dioxus::prelude::*;
 use futures_timer::Delay;
-use moto_core::api::{ApiClient, AuthenticatedRequestError, GetVehicleError};
-use moto_core::models::{NearbyRideRequest, apply_nearby_ride_event};
+use moto_core::api::{AcceptRideError, ApiClient, AuthenticatedRequestError, GetVehicleError};
+use moto_core::models::{NearbyRideRequest, Ride, apply_nearby_ride_event};
 use moto_core::realtime::{
     ConnectionState, PollAction, RealtimeClient, RealtimeConfig, SubscribeFailureAction,
     decide_poll_action, decide_subscribe_failure,
@@ -164,6 +175,11 @@ fn NearbyRidesList(props: NearbyRidesListProps) -> Element {
 
     let mut status = use_signal(|| RealtimeStatus::Connecting);
     let mut requests = use_signal(Vec::<NearbyRideRequest>::new);
+    // Viaje que este conductor acabo de aceptar (issue #17). Una vez
+    // presente, la pantalla deja de mostrar la lista: el backend no deja
+    // aceptar un segundo viaje mientras el conductor tenga uno activo, asi
+    // que seguir ofreciendo la lista no serviria de nada.
+    let mut accepted_ride = use_signal(|| None::<Ride>);
     // El loop de sondeo corre para siempre mientras la pantalla este
     // montada (Dioxus cancela la tarea al desmontar el componente, ver
     // `Home` en `moto_ui/src/lib.rs`) — esta bandera solo evita levantar un
@@ -275,35 +291,127 @@ fn NearbyRidesList(props: NearbyRidesListProps) -> Element {
     rsx! {
         div { class: "nearby-rides-screen",
             h2 { "Solicitudes cercanas" }
-            match status() {
-                RealtimeStatus::Connecting => rsx! {
-                    p { "Conectando..." }
-                },
-                RealtimeStatus::Reconnecting => rsx! {
-                    p { "Reconectando..." }
-                },
-                RealtimeStatus::Unavailable(message) => rsx! {
-                    p { class: "nearby-rides-error", role: "alert", "{message}" }
-                },
-                RealtimeStatus::Connected => rsx! {
-                    if requests().is_empty() {
-                        p { class: "nearby-rides-empty", "No hay solicitudes disponibles por el momento." }
-                    } else {
-                        ul { class: "nearby-rides-list",
-                            for request in requests() {
-                                li { key: "{request.ride_id}", class: "nearby-ride-request",
-                                    p {
-                                        "Origen: {request.origin.latitude}, {request.origin.longitude}"
+            if let Some(ride) = accepted_ride() {
+                div { class: "nearby-ride-accepted",
+                    p { "Aceptaste el viaje." }
+                    p { "Tarifa estimada: {ride.currency} {ride.estimated_fare}" }
+                }
+            } else {
+                match status() {
+                    RealtimeStatus::Connecting => rsx! {
+                        p { "Conectando..." }
+                    },
+                    RealtimeStatus::Reconnecting => rsx! {
+                        p { "Reconectando..." }
+                    },
+                    RealtimeStatus::Unavailable(message) => rsx! {
+                        p { class: "nearby-rides-error", role: "alert", "{message}" }
+                    },
+                    RealtimeStatus::Connected => rsx! {
+                        if requests().is_empty() {
+                            p { class: "nearby-rides-empty", "No hay solicitudes disponibles por el momento." }
+                        } else {
+                            ul { class: "nearby-rides-list",
+                                for request in requests() {
+                                    NearbyRideRow {
+                                        key: "{request.ride_id}",
+                                        request: request.clone(),
+                                        on_accepted: move |ride: Ride| {
+                                            let ride_id = ride.id;
+                                            requests.with_mut(|list| list.retain(|r| r.ride_id != ride_id));
+                                            accepted_ride.set(Some(ride));
+                                        },
+                                        on_unavailable: move |ride_id: u64| {
+                                            requests.with_mut(|list| list.retain(|r| r.ride_id != ride_id));
+                                        },
                                     }
-                                    p {
-                                        "Destino: {request.destination.latitude}, {request.destination.longitude}"
-                                    }
-                                    p { "Tarifa estimada: {request.currency} {request.estimated_fare}" }
                                 }
                             }
                         }
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct NearbyRideRowProps {
+    request: NearbyRideRequest,
+    on_accepted: EventHandler<Ride>,
+    on_unavailable: EventHandler<u64>,
+}
+
+/// Una solicitud de la lista con su boton "Aceptar" (issue #17). Componente
+/// aparte (en vez de logica inline en el `for` de `NearbyRidesList`) para que
+/// cada fila tenga su propio estado de carga/error sin afectar a las demas —
+/// dos solicitudes pueden estar aceptandose (o fallando) al mismo tiempo.
+#[component]
+fn NearbyRideRow(props: NearbyRideRowProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut is_accepting = use_signal(|| false);
+    let mut error = use_signal(|| None::<String>);
+
+    let ride_id = props.request.ride_id;
+    let on_accepted = props.on_accepted;
+    let on_unavailable = props.on_unavailable;
+
+    let on_accept_click = move |_| {
+        let Some(token) = session.token() else {
+            return;
+        };
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_accepting.set(true);
+            error.set(None);
+
+            match api_client.accept_ride(&token, ride_id).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
                     }
-                },
+                    on_accepted.call(fetch.data);
+                }
+                Err(AcceptRideError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(AcceptRideError::Conflict) => {
+                    on_unavailable.call(ride_id);
+                }
+                Err(err) => {
+                    error.set(Some(err.to_string()));
+                }
+            }
+
+            is_accepting.set(false);
+        });
+    };
+
+    rsx! {
+        li { class: "nearby-ride-request",
+            p { "Origen: {props.request.origin.latitude}, {props.request.origin.longitude}" }
+            p {
+                "Destino: {props.request.destination.latitude}, {props.request.destination.longitude}"
+            }
+            p { "Tarifa estimada: {props.request.currency} {props.request.estimated_fare}" }
+            button {
+                r#type: "button",
+                class: "nearby-ride-accept-button",
+                disabled: is_accepting(),
+                onclick: on_accept_click,
+                if is_accepting() {
+                    "Aceptando..."
+                } else {
+                    "Aceptar"
+                }
+            }
+            if let Some(message) = error() {
+                p { class: "nearby-ride-accept-error", role: "alert", "{message}" }
             }
         }
     }


### PR DESCRIPTION
Closes #17

## Qué hace

Agrega `ApiClient::accept_ride` (`POST /api/v1/rides/{ride}/accept`,
`crates/moto_core/src/api.rs`), siguiendo el mismo patrón que
`cancel_ride` (issue #15): reintenta una vez con refresh de token ante
un 401, y no reintenta 403/404/409/422. Verifiqué el contrato real
contra `Back_App_MotoCarros` (`routes/api.php`, `AcceptRideController`,
`AcceptRideAction`, y la sección `/rides/{id}/accept` de
`openapi.yaml`) antes de implementar:

- `AcceptRideError`: `Forbidden` (403, cuenta no conductora), `NotFound`
  (404), `Conflict` (409 — dos conductores intentan aceptar el mismo
  viaje casi al mismo tiempo, el segundo pierde la carrera),
  `Validation` (422 — el conductor ya tiene un viaje propio activo),
  `SessionExpired`, `Network`, `Unexpected`.
- `NearbyRidesList` (`crates/moto_ui/src/screens/nearby_rides.rs`):
  cada solicitud de la lista ahora es un componente `NearbyRideRow` con
  su propio botón "Aceptar" y su propio estado de carga/error (dos
  solicitudes pueden estar aceptándose en paralelo sin interferir). Al
  aceptar con éxito, la pantalla deja de mostrar la lista y muestra el
  viaje aceptado — el backend no deja aceptar un segundo viaje mientras
  el conductor tenga uno activo, así que seguir ofreciendo la lista no
  tendría sentido. Ante un 409, la solicitud se saca de la lista con un
  mensaje explícito ("Este viaje ya no está disponible.") en vez de un
  error genérico, tal como pide el criterio de aceptación del issue.

## Cómo se probó

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude mobile` (142 tests en total, 8
  nuevos para `accept_ride` con HTTP mockeado vía `wiremock`: éxito con
  conductor asignado, 403, 404, 409, 422 con desglose por campo,
  401+refresh, `SessionExpired`, y red inalcanzable)
- `cargo build --package web --target wasm32-unknown-unknown` compila
  sin errores

No se agregaron tests de UI: no existe scaffolding de tests para
`moto_ui` en este repo (consistente con el criterio ya establecido en
PRs anteriores, p. ej. #42).

## Decisiones y riesgos

- **Sin navegación a una pantalla de "viaje en curso"**: no existe
  todavía ninguna pantalla para eso — "Iniciar el viaje aceptado"
  (#18) y las historias posteriores de tracking (#19/#20) siguen
  abiertas. Tras aceptar, esta misma pantalla (`NearbyRidesList`) pasa
  a mostrar un resumen simple del viaje aceptado en vez de navegar a
  otro lado. Cuando #18 exista, esa pantalla puede reemplazar este
  resumen.
- **Componente `NearbyRideRow` en vez de lógica inline en el `for`**:
  Dioxus rsx no admite mezclar `let` bindings sueltos con nodos dentro
  del cuerpo de un `for`, y cada fila necesita su propio estado de
  carga/error independiente (dos conductores... digo, dos solicitudes
  pueden aceptarse en paralelo). Extraerlo a un componente aparte
  evita ese problema y sigue el mismo patrón que ya usa el resto del
  repo (componentes con props + `EventHandler`, ver `login.rs`,
  `profile.rs`).
- **El loop de sondeo en tiempo real sigue corriendo tras aceptar**: no
  lo corto explícitamente al aceptar — simplemente deja de importar
  porque la UI ya no muestra la lista. Cortarlo requeriría tocar la
  máquina de estados de `moto_core::realtime`, fuera de alcance de este
  issue.