### PR TITLE
feat(#19): compartir mi ubicacion en tiempo real durante el viaje

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5965,6 +5965,7 @@ dependencies = [
  "dioxus",
  "moto_core",
  "moto_ui",
+ "serde",
  "serde_json",
  "web-sys",
 ]

--- a/crates/mobile/src/location.rs
+++ b/crates/mobile/src/location.rs
@@ -1,0 +1,31 @@
+//! Puente de ubicacion para movil nativo — issue #19.
+//!
+//! TODO(issue de seguimiento): esto deberia usar la API de ubicacion nativa
+//! de Android/iOS (con soporte real de segundo plano, a diferencia del
+//! target web). Todavia no hay puente nativo (proyecto Xcode/Gradle) en
+//! este esqueleto para exponer esas APIs a Rust — mismo criterio que
+//! `InMemoryTokenStorage` en `main.rs`. `NativeLocationProvider` siempre
+//! devuelve `Unavailable` de forma explicita y documentada, no un descuido:
+//! evita que la app entre en panico por falta de contexto, sin fingir que
+//! el tracking en movil ya funciona.
+
+use moto_core::location::{LocationError, LocationFuture, LocationProvider};
+
+#[derive(Debug, Default)]
+pub struct NativeLocationProvider;
+
+impl NativeLocationProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl LocationProvider for NativeLocationProvider {
+    fn current_position(&self) -> LocationFuture {
+        Box::pin(async move {
+            Err(LocationError::Unavailable(
+                "Compartir ubicacion todavia no esta disponible en la app movil.".to_string(),
+            ))
+        })
+    }
+}

--- a/crates/mobile/src/main.rs
+++ b/crates/mobile/src/main.rs
@@ -2,9 +2,14 @@ use std::sync::Arc;
 
 use dioxus::prelude::*;
 use moto_core::api::ApiClient;
+use moto_core::location::LocationProvider;
 use moto_core::realtime::RealtimeConfig;
 use moto_core::storage::{InMemoryTokenStorage, TokenStorage};
 use moto_ui::App;
+
+mod location;
+
+use location::NativeLocationProvider;
 
 /// Fallback de desarrollo local. La URL real del backend se inyecta en build
 /// time via la variable de entorno `MOTOYA_API_BASE_URL` (nunca hardcodeada
@@ -37,6 +42,12 @@ fn main() {
         // tampoco guarda el token en texto plano en disco.
         .with_context_provider(|| {
             Box::new(Arc::new(InMemoryTokenStorage::new()) as Arc<dyn TokenStorage>)
+        })
+        // TODO(issue de seguimiento): reemplazar por un `LocationProvider`
+        // que use la API de ubicacion nativa cuando exista el puente
+        // Xcode/Gradle — ver `crates/mobile/src/location.rs`.
+        .with_context_provider(|| {
+            Box::new(Arc::new(NativeLocationProvider::new()) as Arc<dyn LocationProvider>)
         })
         .launch(App);
 }

--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -762,6 +762,50 @@ impl std::fmt::Display for StartRideError {
 
 impl std::error::Error for StartRideError {}
 
+/// Fallos posibles de `POST /api/v1/rides/{ride}/location` (issue #19).
+///
+/// Mismo reparto que `StartRideError`: `Forbidden` cubre tanto a un
+/// conductor distinto del asignado como a un viaje sin conductor asignado
+/// todavia. `Validation` cubre en cambio que el viaje ya no este
+/// `in_progress`, o que las coordenadas esten fuera de rango (aunque esto
+/// ultimo no deberia pasar si `LocationProvider` devuelve datos validos).
+#[derive(Debug, Clone, PartialEq)]
+pub enum ShareRideLocationError {
+    Forbidden,
+    /// No existe ningun viaje con ese id.
+    NotFound,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for ShareRideLocationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShareRideLocationError::Forbidden => {
+                write!(f, "Este viaje no te pertenece.")
+            }
+            ShareRideLocationError::NotFound => write!(f, "El viaje ya no existe."),
+            ShareRideLocationError::Validation(body) => write!(f, "{}", body.message),
+            ShareRideLocationError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            ShareRideLocationError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            ShareRideLocationError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ShareRideLocationError {}
+
 /// Fallos posibles de `POST /api/v1/broadcasting/auth` (issue #5).
 ///
 /// A diferencia del resto de las requests autenticadas, esta nunca reintenta
@@ -867,6 +911,14 @@ enum AcceptRideOutcome {
 
 enum StartRideOutcome {
     Success(Ride),
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    Validation(ApiErrorBody),
+}
+
+enum ShareRideLocationOutcome {
+    Success,
     Unauthorized,
     Forbidden,
     NotFound,
@@ -2069,6 +2121,98 @@ impl ApiClient {
                 Ok(StartRideOutcome::Validation(body))
             }
             other => Err(StartRideError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/rides/{ride}/location` — issue #19. No hay ningun
+    /// recurso que devolver (el backend responde 204: la ubicacion no se
+    /// persiste, solo se transmite por el canal `ride.{id}`, ver
+    /// `ShareRideLocationController` de `Back_App_MotoCarros`). Mismo
+    /// reparto que `start_ride`: reintenta una vez con refresh de token ante
+    /// un 401; un 403 (viaje ajeno o sin conductor asignado), 404 (no
+    /// existe) o 422 (el viaje ya no esta `in_progress`, o coordenadas fuera
+    /// de rango) nunca se reintentan.
+    pub async fn share_ride_location(
+        &self,
+        token: &AuthToken,
+        ride_id: u64,
+        location: Coordinates,
+    ) -> Result<AuthenticatedFetch<()>, ShareRideLocationError> {
+        match self
+            .post_location_with_token(ride_id, &token.access_token, &location)
+            .await?
+        {
+            ShareRideLocationOutcome::Success => {
+                return Ok(AuthenticatedFetch {
+                    data: (),
+                    refreshed_token: None,
+                });
+            }
+            ShareRideLocationOutcome::Forbidden => return Err(ShareRideLocationError::Forbidden),
+            ShareRideLocationOutcome::NotFound => return Err(ShareRideLocationError::NotFound),
+            ShareRideLocationOutcome::Validation(body) => {
+                return Err(ShareRideLocationError::Validation(body));
+            }
+            ShareRideLocationOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| ShareRideLocationError::SessionExpired)?;
+
+        match self
+            .post_location_with_token(ride_id, &renewed.access_token, &location)
+            .await?
+        {
+            ShareRideLocationOutcome::Success => Ok(AuthenticatedFetch {
+                data: (),
+                refreshed_token: Some(renewed),
+            }),
+            ShareRideLocationOutcome::Forbidden => Err(ShareRideLocationError::Forbidden),
+            ShareRideLocationOutcome::NotFound => Err(ShareRideLocationError::NotFound),
+            ShareRideLocationOutcome::Validation(body) => {
+                Err(ShareRideLocationError::Validation(body))
+            }
+            ShareRideLocationOutcome::Unauthorized => Err(ShareRideLocationError::SessionExpired),
+        }
+    }
+
+    async fn post_location_with_token(
+        &self,
+        ride_id: u64,
+        access_token: &str,
+        location: &Coordinates,
+    ) -> Result<ShareRideLocationOutcome, ShareRideLocationError> {
+        let url = format!("{}/api/v1/rides/{}/location", self.base_url, ride_id);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .json(location)
+            .send()
+            .await
+            .map_err(|err| ShareRideLocationError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            return Ok(ShareRideLocationOutcome::Success);
+        }
+
+        match status.as_u16() {
+            401 => Ok(ShareRideLocationOutcome::Unauthorized),
+            403 => Ok(ShareRideLocationOutcome::Forbidden),
+            404 => Ok(ShareRideLocationOutcome::NotFound),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| ShareRideLocationError::Network(err.to_string()))?;
+                Ok(ShareRideLocationOutcome::Validation(body))
+            }
+            other => Err(ShareRideLocationError::Unexpected(other)),
         }
     }
 
@@ -4808,6 +4952,209 @@ mod tests {
         let error = client.start_ride(&sample_token(), 1).await.unwrap_err();
 
         assert!(matches!(error, StartRideError::Network(_)));
+    }
+
+    fn sample_location() -> Coordinates {
+        Coordinates {
+            latitude: 4.710989,
+            longitude: -74.072092,
+        }
+    }
+
+    #[tokio::test]
+    async fn share_ride_location_succeeds_on_204() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/location"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .and(body_json(serde_json::json!({
+                "latitude": 4.710989,
+                "longitude": -74.072092,
+            })))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .share_ride_location(&sample_token(), 1, sample_location())
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data, ());
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn share_ride_location_returns_forbidden_on_403_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/location"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .share_ride_location(&sample_token(), 1, sample_location())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, ShareRideLocationError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn share_ride_location_returns_not_found_on_404_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/999/location"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "No query results for model [App\\Models\\Ride] 999.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .share_ride_location(&sample_token(), 999, sample_location())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, ShareRideLocationError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn share_ride_location_returns_validation_error_on_422_when_the_ride_is_not_in_progress()
+    {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/location"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Solo se puede compartir ubicacion en un viaje en curso.",
+                "errors": {
+                    "ride": ["Solo se puede compartir ubicacion en un viaje en curso."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .share_ride_location(&sample_token(), 1, sample_location())
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            ShareRideLocationError::Validation(ApiErrorBody {
+                message: "Solo se puede compartir ubicacion en un viaje en curso.".to_string(),
+                errors: Some(HashMap::from([(
+                    "ride".to_string(),
+                    vec!["Solo se puede compartir ubicacion en un viaje en curso.".to_string()]
+                )])),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn share_ride_location_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/location"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/location"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .share_ride_location(&sample_token(), 1, sample_location())
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn share_ride_location_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/location"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .share_ride_location(&sample_token(), 1, sample_location())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, ShareRideLocationError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn share_ride_location_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .share_ride_location(&sample_token(), 1, sample_location())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ShareRideLocationError::Network(_)));
     }
 
     #[tokio::test]

--- a/crates/moto_core/src/lib.rs
+++ b/crates/moto_core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod location;
 pub mod models;
 pub mod realtime;
 pub mod state;

--- a/crates/moto_core/src/location.rs
+++ b/crates/moto_core/src/location.rs
@@ -1,0 +1,54 @@
+//! Abstraccion de obtencion de la posicion actual del dispositivo,
+//! especifica por plataforma (issue #19).
+//!
+//! `moto_core` no sabe *como* se consigue la posicion — solo define el
+//! contrato. Cada binario de plataforma (`web`/`mobile`) provee la
+//! implementacion real y la inyecta via contexto de Dioxus, igual que ya
+//! hace con `TokenStorage` (ver `.claude/STANDARDS.md`).
+
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::models::Coordinates;
+
+/// Fallo al pedir la posicion actual. `PermissionDenied` es el unico caso
+/// que la UI necesita distinguir explicitamente del resto (criterio de
+/// aceptacion del issue: pedir habilitar el permiso en vez de fallar en
+/// silencio) — cualquier otro fallo (navegador sin soporte, timeout, GPS
+/// apagado, plataforma sin puente todavia) queda bajo `Unavailable` con un
+/// mensaje ya listo para mostrar.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LocationError {
+    PermissionDenied,
+    Unavailable(String),
+}
+
+impl std::fmt::Display for LocationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LocationError::PermissionDenied => write!(
+                f,
+                "Habilita el permiso de ubicacion para compartirla durante el viaje."
+            ),
+            LocationError::Unavailable(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for LocationError {}
+
+/// Future sin `Send` que resuelve a la posicion actual: en el target web la
+/// obtiene `navigator.geolocation` del navegador via un `JsFuture` (que no
+/// es `Send`, ver `crates/web/src/geolocation.rs`) — Dioxus no lo exige,
+/// porque su modelo de componentes ya corre en un solo hilo (signals
+/// `!Send`), igual que el resto de este crate.
+pub type LocationFuture = Pin<Box<dyn Future<Output = Result<Coordinates, LocationError>>>>;
+
+/// Consigue la posicion actual del dispositivo. Cada plataforma decide el
+/// mecanismo real: web usa `navigator.geolocation` (ver
+/// `crates/web/src/geolocation.rs`); movil todavia no tiene puente a la API
+/// nativa de ubicacion (ver `crates/mobile/src/location.rs`, mismo criterio
+/// documentado que `InMemoryTokenStorage`).
+pub trait LocationProvider: std::fmt::Debug {
+    fn current_position(&self) -> LocationFuture;
+}

--- a/crates/moto_ui/src/screens/nearby_rides.rs
+++ b/crates/moto_ui/src/screens/nearby_rides.rs
@@ -37,6 +37,19 @@
 //! (criterio de aceptacion del issue). Al iniciar con exito, la pantalla
 //! reemplaza el viaje en pantalla por la version devuelta por el backend
 //! (ahora `in_progress`, con `started_at`) en vez de solo esconder el boton.
+//!
+//! Mientras el viaje siga en `in_progress`, `ShareLocationPanel` publica
+//! periodicamente la posicion del conductor con
+//! `POST /api/v1/rides/{ride}/location` (`ApiClient::share_ride_location`,
+//! issue #19). La posicion misma la consigue un `LocationProvider` inyectado
+//! por plataforma (web/movil, ver `moto_core::location`) — este componente
+//! solo decide cuando pedirla y que hacer con el resultado, sin saber como
+//! se obtiene. Si el proveedor devuelve `LocationError::PermissionDenied`,
+//! el panel lo muestra explicitamente y deja de intentar: no tiene sentido
+//! seguir pidiendo permiso sin que el usuario actue. Cualquier otro fallo
+//! (de red, del backend, o del propio proveedor) se trata como transitorio y
+//! se reintenta en el siguiente ciclo, sin dejar el panel en un estado de
+//! error permanente.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -44,8 +57,10 @@ use std::time::Duration;
 use dioxus::prelude::*;
 use futures_timer::Delay;
 use moto_core::api::{
-    AcceptRideError, ApiClient, AuthenticatedRequestError, GetVehicleError, StartRideError,
+    AcceptRideError, ApiClient, AuthenticatedRequestError, GetVehicleError, ShareRideLocationError,
+    StartRideError,
 };
+use moto_core::location::{LocationError, LocationProvider};
 use moto_core::models::{NearbyRideRequest, Ride, RideStatus, apply_nearby_ride_event};
 use moto_core::realtime::{
     ConnectionState, PollAction, RealtimeClient, RealtimeConfig, SubscribeFailureAction,
@@ -61,6 +76,14 @@ use super::register_vehicle::RegisterVehicleScreen;
 /// `.claude/STANDARDS.md`, el crate no tiene runtime propio), asi que la
 /// pantalla lo consulta activamente a este ritmo.
 const POLL_INTERVAL: Duration = Duration::from_millis(700);
+
+/// Intervalo entre publicaciones de ubicacion de `ShareLocationPanel` (issue
+/// #19). Mas espaciado que `POLL_INTERVAL`: a diferencia del sondeo de
+/// eventos, pedirle la posicion al dispositivo tiene un costo real
+/// (bateria, y en el navegador un posible reprompt de permiso), y el
+/// pasajero no necesita una actualizacion mas fina que esta para seguir el
+/// viaje en el mapa.
+const LOCATION_SHARE_INTERVAL: Duration = Duration::from_secs(10);
 
 #[component]
 pub fn NearbyRidesScreen() -> Element {
@@ -313,7 +336,7 @@ fn NearbyRidesList(props: NearbyRidesListProps) -> Element {
                             },
                         }
                     } else if ride.status == RideStatus::InProgress {
-                        p { "Viaje en curso." }
+                        ShareLocationPanel { ride_id: ride.id }
                     }
                 }
             } else {
@@ -503,6 +526,116 @@ fn StartRideButton(props: StartRideButtonProps) -> Element {
             }
             if let Some(message) = error() {
                 p { class: "nearby-ride-start-error", role: "alert", "{message}" }
+            }
+        }
+    }
+}
+
+/// Estado visible de `ShareLocationPanel` (issue #19).
+#[derive(Debug, Clone, PartialEq)]
+enum SharingStatus {
+    Sharing,
+    PermissionDenied,
+    Error(String),
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct ShareLocationPanelProps {
+    ride_id: u64,
+}
+
+/// Publica la posicion del conductor mientras el viaje siga `in_progress`
+/// (issue #19). Componente aparte, igual que `StartRideButton`, para que su
+/// ciclo de vida (arranca al montarse, Dioxus lo cancela al desmontarse)
+/// quede acotado a mientras el viaje este en curso: cuando el viaje pase a
+/// `completed`/`cancelled`, `NearbyRidesList` deja de renderizar este
+/// componente y el loop de mas abajo se corta solo.
+#[component]
+fn ShareLocationPanel(props: ShareLocationPanelProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+    let location_provider = use_context::<Arc<dyn LocationProvider>>();
+
+    let mut status = use_signal(|| SharingStatus::Sharing);
+    // Mismo criterio que el resto de los loops de esta pantalla: evita
+    // levantar un segundo loop si el efecto se vuelve a disparar.
+    let mut started = use_signal(|| false);
+
+    let ride_id = props.ride_id;
+
+    use_effect(move || {
+        if started() {
+            return;
+        }
+        started.set(true);
+
+        let Some(token) = session.token() else {
+            status.set(SharingStatus::Error(
+                "La sesion expiro. Inicia sesion de nuevo.".to_string(),
+            ));
+            return;
+        };
+
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+        let location_provider = location_provider.clone();
+
+        spawn(async move {
+            let mut current_token = token;
+
+            loop {
+                match location_provider.current_position().await {
+                    Ok(coordinates) => {
+                        match api_client
+                            .share_ride_location(&current_token, ride_id, coordinates)
+                            .await
+                        {
+                            Ok(fetch) => {
+                                if let Some(refreshed) = fetch.refreshed_token {
+                                    session.update_token(refreshed.clone(), storage.as_ref());
+                                    current_token = refreshed;
+                                }
+                                status.set(SharingStatus::Sharing);
+                            }
+                            Err(ShareRideLocationError::SessionExpired) => {
+                                session.logout(storage.as_ref());
+                                break;
+                            }
+                            Err(err) => {
+                                status.set(SharingStatus::Error(err.to_string()));
+                            }
+                        }
+                    }
+                    Err(LocationError::PermissionDenied) => {
+                        status.set(SharingStatus::PermissionDenied);
+                        break;
+                    }
+                    Err(LocationError::Unavailable(message)) => {
+                        status.set(SharingStatus::Error(message));
+                    }
+                }
+
+                Delay::new(LOCATION_SHARE_INTERVAL).await;
+            }
+        });
+    });
+
+    rsx! {
+        div { class: "share-location-panel",
+            p { "Viaje en curso." }
+            match status() {
+                SharingStatus::Sharing => rsx! {
+                    p { class: "share-location-status", "Compartiendo tu ubicacion..." }
+                },
+                SharingStatus::PermissionDenied => rsx! {
+                    p { class: "share-location-error", role: "alert",
+                        "Habilita el permiso de ubicacion para compartirla durante el viaje."
+                    }
+                },
+                SharingStatus::Error(message) => rsx! {
+                    p { class: "share-location-error", role: "alert", "{message}" }
+                },
             }
         }
     }

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -7,5 +7,6 @@ edition.workspace = true
 dioxus = { workspace = true, features = ["web"] }
 moto_ui = { path = "../moto_ui" }
 moto_core = { path = "../moto_core" }
+serde.workspace = true
 serde_json.workspace = true
 web-sys = { version = "0.3", features = ["Window", "Storage"] }

--- a/crates/web/src/geolocation.rs
+++ b/crates/web/src/geolocation.rs
@@ -1,0 +1,96 @@
+//! Obtencion de la posicion actual via `navigator.geolocation` del
+//! navegador — issue #19.
+//!
+//! Usa `dioxus::document::eval` para invocar la API del navegador, mismo
+//! mecanismo que `MapView` (`moto_ui::map`) para Leaflet: es parte del core
+//! de Dioxus, no requiere `#[cfg(target_arch = "wasm32")]` disperso. La
+//! diferencia con Leaflet es que aca el resultado es un solo valor (o un
+//! fallo), no un stream de eventos — el script manda exactamente un mensaje
+//! por invocacion via `dioxus.send`.
+//!
+//! Riesgo de arquitectura conocido (ver `.claude/CLAUDE.md`): esto solo
+//! funciona mientras la pestana esta en primer plano. Los navegadores
+//! suspenden o limitan fuertemente `navigator.geolocation` con la pantalla
+//! apagada o la app minimizada/en segundo plano — no hay forma de superar
+//! esa limitacion desde JS de pagina. Si el piloto necesita tracking en
+//! segundo plano confiable para el conductor, la salida es el shell nativo
+//! delgado que ya anticipa `.claude/CLAUDE.md`, con una implementacion de
+//! `LocationProvider` propia en `crates/mobile` que use la API de ubicacion
+//! del sistema operativo en vez de esto.
+
+use dioxus::prelude::*;
+use moto_core::location::{LocationError, LocationFuture, LocationProvider};
+use moto_core::models::Coordinates;
+
+const GEOLOCATION_SCRIPT: &str = r#"
+(function () {
+    if (!navigator.geolocation) {
+        dioxus.send({ kind: "error", message: "Este navegador no soporta geolocalizacion." });
+        return;
+    }
+    navigator.geolocation.getCurrentPosition(
+        function (position) {
+            dioxus.send({
+                kind: "success",
+                latitude: position.coords.latitude,
+                longitude: position.coords.longitude,
+            });
+        },
+        function (error) {
+            if (error.code === error.PERMISSION_DENIED) {
+                dioxus.send({ kind: "denied" });
+            } else {
+                dioxus.send({
+                    kind: "error",
+                    message: error.message || "No se pudo obtener la ubicacion.",
+                });
+            }
+        },
+        { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
+    );
+})();
+"#;
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(tag = "kind")]
+enum GeolocationEvent {
+    #[serde(rename = "success")]
+    Success { latitude: f64, longitude: f64 },
+    #[serde(rename = "denied")]
+    Denied,
+    #[serde(rename = "error")]
+    Error { message: String },
+}
+
+#[derive(Debug, Default)]
+pub struct WebLocationProvider;
+
+impl WebLocationProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl LocationProvider for WebLocationProvider {
+    fn current_position(&self) -> LocationFuture {
+        Box::pin(async move {
+            let mut eval = document::eval(GEOLOCATION_SCRIPT);
+            let event: GeolocationEvent = eval
+                .recv()
+                .await
+                .map_err(|err| LocationError::Unavailable(err.to_string()))?;
+
+            match event {
+                GeolocationEvent::Success {
+                    latitude,
+                    longitude,
+                } => Ok(Coordinates {
+                    latitude,
+                    longitude,
+                }),
+                GeolocationEvent::Denied => Err(LocationError::PermissionDenied),
+                GeolocationEvent::Error { message } => Err(LocationError::Unavailable(message)),
+            }
+        })
+    }
+}

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -2,12 +2,15 @@ use std::sync::Arc;
 
 use dioxus::prelude::*;
 use moto_core::api::ApiClient;
+use moto_core::location::LocationProvider;
 use moto_core::realtime::RealtimeConfig;
 use moto_core::storage::TokenStorage;
 use moto_ui::App;
 
+mod geolocation;
 mod storage;
 
+use geolocation::WebLocationProvider;
 use storage::WebTokenStorage;
 
 /// Fallback de desarrollo local. La URL real del backend se inyecta en build
@@ -34,6 +37,9 @@ fn main() {
         })
         .with_context_provider(|| {
             Box::new(Arc::new(WebTokenStorage::new()) as Arc<dyn TokenStorage>)
+        })
+        .with_context_provider(|| {
+            Box::new(Arc::new(WebLocationProvider::new()) as Arc<dyn LocationProvider>)
         })
         .launch(App);
 }


### PR DESCRIPTION
Closes #19

## Que hace

- `ApiClient::share_ride_location` (`POST /api/v1/rides/{ride}/location`, `crates/moto_core/src/api.rs`) con el mismo reparto de errores que `start_ride`: `Forbidden`/`NotFound`/`Validation`, y reintento con refresh de token ante un 401. El backend responde 204 sin cuerpo, asi que el `Ok` trae `()`.
- `moto_core::location`: contrato `LocationProvider` (mas `LocationError::{PermissionDenied, Unavailable}`) para que `moto_core`/`moto_ui` no sepan como se obtiene la posicion real — mismo patron ya usado por `TokenStorage`.
- `WebLocationProvider` (`crates/web/src/geolocation.rs`): usa `navigator.geolocation.getCurrentPosition` via `dioxus::document::eval` (mismo mecanismo que `MapView`/Leaflet), distinguiendo el permiso denegado (`PERMISSION_DENIED`) del resto de fallos.
- `NativeLocationProvider` (`crates/mobile/src/location.rs`): stub explicito que siempre responde `Unavailable`, documentado igual que `InMemoryTokenStorage` — todavia no hay puente nativo Xcode/Gradle para exponer la API de ubicacion del sistema.
- `ShareLocationPanel` en `NearbyRidesScreen` (`crates/moto_ui/src/screens/nearby_rides.rs`): mientras el viaje siga `in_progress`, pide la posicion cada 10s y la publica. Si el proveedor devuelve `PermissionDenied`, muestra un mensaje explicito y corta el loop (no tiene sentido seguir insistiendo sin que el usuario actue). Cualquier otro fallo (red, backend, proveedor) se trata como transitorio: se muestra el mensaje pero se sigue reintentando en el siguiente ciclo.

## Como se probo

- `cargo test --workspace --exclude mobile`: 156 tests en verde, incluye 7 tests nuevos de `share_ride_location` en `moto_core` (exito 204, 403, 404, 422, refresh-and-retry en 401, `SessionExpired` cuando el refresh falla, error de red) mockeados con `wiremock`.
- `cargo fmt --all -- --check` y `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`: sin errores.
- `cargo build --package web --target wasm32-unknown-unknown`: compila.
- `cargo check --package mobile`: compila (no es parte del CI por PR, pero lo dejo verificado ya que el issue toca `crates/mobile` para el stub del provider).
- El renderizado real de `ShareLocationPanel` en navegador no se probo manualmente (sin sesion de conductor con un viaje `in_progress` a mano en este entorno) — sigue el mismo patron ya validado de `StartRideButton`/`NearbyRideRow` en este mismo archivo, y no se testea en CI por decision de `.claude/STANDARDS.md`.

## Decisiones y riesgos

- **Limitacion de background conocida (issue lo pide explicito):** esto solo funciona con la pestana en primer plano. Los navegadores suspenden/limitan fuertemente `navigator.geolocation` con la pantalla apagada o la app minimizada, y no hay forma de evitarlo desde JS de pagina — documentado en el doc comment de `crates/web/src/geolocation.rs`, remite a la salida ya anticipada en `.claude/CLAUDE.md` (shell nativo delgado para el conductor si el piloto lo necesita).
- **Intervalo de publicacion:** 10s (`LOCATION_SHARE_INTERVAL`), mas espaciado que el sondeo de tiempo real de 700ms de esta misma pantalla — pedir la posicion tiene costo real de bateria y puede re-disparar el prompt de permiso en algunos navegadores.
- **Trait sin `Send`:** `LocationProvider::current_position` devuelve un futuro boxeado sin bound `Send` (como `TokenStorage`, que tampoco lo tiene) porque el `JsFuture` que envuelve `navigator.geolocation` no es `Send` — el modelo de componentes de Dioxus ya es de un solo hilo, asi que no hace falta.
- **Mobile:** el issue nota que la geolocalizacion es especifica de plataforma y no pertenece a `moto_core`/`moto_ui`; agregue el stub de `crates/mobile` para que la app movil no entre en panico por falta de contexto al llegar a esta pantalla, con un TODO explicito para cuando exista el puente nativo real.