### PR TITLE
feat(#20): ver estado y ubicacion del viaje en tiempo real

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -806,6 +806,44 @@ impl std::fmt::Display for ShareRideLocationError {
 
 impl std::error::Error for ShareRideLocationError {}
 
+/// Fallos posibles de `GET /api/v1/rides/{ride}` (issue #20).
+///
+/// `Forbidden` cubre una cuenta que ni pidio el viaje ni es el conductor
+/// asignado (`RidePolicy::view` en el backend responde 403 y no 404 a
+/// proposito, para no filtrar si el id existe). `NotFound` es que no existe
+/// ningun viaje con ese id.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GetRideError {
+    Forbidden,
+    NotFound,
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for GetRideError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GetRideError::Forbidden => write!(f, "Este viaje no te pertenece."),
+            GetRideError::NotFound => write!(f, "El viaje ya no existe."),
+            GetRideError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            GetRideError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            GetRideError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GetRideError {}
+
 /// Fallos posibles de `POST /api/v1/broadcasting/auth` (issue #5).
 ///
 /// A diferencia del resto de las requests autenticadas, esta nunca reintenta
@@ -923,6 +961,13 @@ enum ShareRideLocationOutcome {
     Forbidden,
     NotFound,
     Validation(ApiErrorBody),
+}
+
+enum GetRideOutcome<T> {
+    Success(T),
+    Unauthorized,
+    Forbidden,
+    NotFound,
 }
 
 impl ApiClient {
@@ -2213,6 +2258,85 @@ impl ApiClient {
                 Ok(ShareRideLocationOutcome::Validation(body))
             }
             other => Err(ShareRideLocationError::Unexpected(other)),
+        }
+    }
+
+    /// `GET /api/v1/rides/{ride}` — issue #20. Consulta puntual que acompana
+    /// al canal privado `ride.{id}`: la pantalla de seguimiento la usa al
+    /// abrirse (y tras reconectar) para no depender solo de eventos en vivo,
+    /// que puede haber perdido mientras el socket estaba caido (ver
+    /// `ShowRideController` de `Back_App_MotoCarros`). Mismo reparto que
+    /// `get_vehicle`: reintenta una vez con refresh de token ante un 401; un
+    /// 403 (viaje ajeno) o 404 (no existe) nunca se reintentan.
+    pub async fn get_ride(
+        &self,
+        token: &AuthToken,
+        ride_id: u64,
+    ) -> Result<AuthenticatedFetch<Ride>, GetRideError> {
+        match self
+            .get_ride_with_token(ride_id, &token.access_token)
+            .await?
+        {
+            GetRideOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            GetRideOutcome::Forbidden => return Err(GetRideError::Forbidden),
+            GetRideOutcome::NotFound => return Err(GetRideError::NotFound),
+            GetRideOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| GetRideError::SessionExpired)?;
+
+        match self
+            .get_ride_with_token(ride_id, &renewed.access_token)
+            .await?
+        {
+            GetRideOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            GetRideOutcome::Forbidden => Err(GetRideError::Forbidden),
+            GetRideOutcome::NotFound => Err(GetRideError::NotFound),
+            GetRideOutcome::Unauthorized => Err(GetRideError::SessionExpired),
+        }
+    }
+
+    async fn get_ride_with_token(
+        &self,
+        ride_id: u64,
+        access_token: &str,
+    ) -> Result<GetRideOutcome<Ride>, GetRideError> {
+        let url = format!("{}/api/v1/rides/{}", self.base_url, ride_id);
+
+        let response = self
+            .http
+            .get(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|err| GetRideError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<Ride> = response
+                .json()
+                .await
+                .map_err(|err| GetRideError::Network(err.to_string()))?;
+            return Ok(GetRideOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(GetRideOutcome::Unauthorized),
+            403 => Ok(GetRideOutcome::Forbidden),
+            404 => Ok(GetRideOutcome::NotFound),
+            other => Err(GetRideError::Unexpected(other)),
         }
     }
 
@@ -5155,6 +5279,152 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, ShareRideLocationError::Network(_)));
+    }
+
+    #[tokio::test]
+    async fn get_ride_returns_the_current_state_of_the_ride() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/1"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": sample_started_ride_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.get_ride(&sample_token(), 1).await.unwrap();
+
+        assert_eq!(fetch.data.id, 1);
+        assert_eq!(fetch.data.status, crate::models::RideStatus::InProgress);
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn get_ride_returns_forbidden_on_403_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/1"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.get_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(error, GetRideError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn get_ride_returns_not_found_on_404_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/999"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "No query results for model [App\\Models\\Ride] 999.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.get_ride(&sample_token(), 999).await.unwrap_err();
+
+        assert_eq!(error, GetRideError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn get_ride_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/1"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/1"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": sample_started_ride_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.get_ride(&sample_token(), 1).await.unwrap();
+
+        assert_eq!(fetch.data.id, 1);
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn get_ride_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/1"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.get_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(error, GetRideError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn get_ride_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client.get_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert!(matches!(error, GetRideError::Network(_)));
     }
 
     #[tokio::test]

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -347,6 +347,103 @@ pub fn apply_nearby_ride_event(
     }
 }
 
+/// Estado que arma la pantalla de seguimiento en tiempo real de un viaje
+/// activo (issue #20): el viaje tal como lo devolvio el ultimo fetch a
+/// `GET /api/v1/rides/{ride}` (`ApiClient::get_ride`), mas la ultima
+/// posicion del conductor que llego por el canal `ride.{id}`. El fetch
+/// nunca trae la ubicacion — solo viaja por el evento `location.updated`,
+/// ver `RideResource` de `Back_App_MotoCarros` — asi que vive aparte del
+/// resto de los campos del viaje en vez de ser un campo mas de `Ride`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RideTracking {
+    pub ride: Ride,
+    pub driver_location: Option<Coordinates>,
+}
+
+impl RideTracking {
+    pub fn new(ride: Ride) -> Self {
+        Self {
+            ride,
+            driver_location: None,
+        }
+    }
+}
+
+/// Payload del evento `status.changed` sobre el canal privado `ride.{id}`
+/// (issue #20): trae el estado **nuevo** y el conductor asignado por id
+/// (`app/Events/Realtime/RideStatusChanged.php` de `Back_App_MotoCarros`).
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+struct RideStatusChangedEvent {
+    status: RideStatus,
+    driver_id: Option<u64>,
+}
+
+/// Payload del evento `location.updated` sobre el mismo canal: la posicion
+/// actual del conductor asignado, publicada por `ShareLocationPanel` (issue
+/// #19) del lado del conductor
+/// (`app/Events/Realtime/DriverLocationUpdated.php` de
+/// `Back_App_MotoCarros`).
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+struct DriverLocationUpdatedEvent {
+    driver_id: u64,
+    latitude: f64,
+    longitude: f64,
+}
+
+/// Aplica un evento del canal `ride.{id}` (issue #20) al estado de
+/// seguimiento que consume la pantalla de tracking (`moto_ui`). Logica
+/// pura y sincronica, mismo criterio que `apply_nearby_ride_event`:
+/// extraida del componente para poder testearla sin Dioxus ni un socket
+/// real. `event_name`/`data` ya vienen filtrados por `channel` en el
+/// caller; un `event_name` desconocido o un `data` que no deserializa al
+/// tipo esperado se ignora sin error (frame corrupto, o version del
+/// protocolo que este cliente no entiende todavia), igual que
+/// `RealtimeClient::handle_frame`.
+///
+/// `location.updated` se ignora si el `driver_id` del evento no coincide
+/// con el conductor asignado al viaje: no deberia pasar
+/// (`RidePolicy::shareLocation` en el backend exige ser el conductor
+/// asignado), pero la pantalla no confia ciegamente en lo que llega por el
+/// canal.
+///
+/// `status.changed` solo trae el id del conductor, no su nombre. Mientras
+/// coincida con el que ya tenia el viaje (o siga sin haber ninguno) no
+/// cambia nada; si aparece un conductor nuevo se guarda con el nombre
+/// vacio en vez de inventarlo — la proxima vez que la pantalla vuelva a
+/// pedir el viaje por HTTP (`GET /api/v1/rides/{ride}`, tras reconectar)
+/// lo completa.
+pub fn apply_ride_tracking_event(tracking: &mut RideTracking, event_name: &str, data: &str) {
+    match event_name {
+        "status.changed" => {
+            if let Ok(event) = serde_json::from_str::<RideStatusChangedEvent>(data) {
+                tracking.ride.status = event.status;
+                match event.driver_id {
+                    None => tracking.ride.driver = None,
+                    Some(id) => {
+                        if tracking.ride.driver.as_ref().map(|d| d.id) != Some(id) {
+                            tracking.ride.driver = Some(RideDriver {
+                                id,
+                                name: String::new(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        "location.updated" => {
+            if let Ok(event) = serde_json::from_str::<DriverLocationUpdatedEvent>(data)
+                && tracking.ride.driver.as_ref().map(|d| d.id) == Some(event.driver_id)
+            {
+                tracking.driver_location = Some(Coordinates {
+                    latitude: event.latitude,
+                    longitude: event.longitude,
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -770,5 +867,166 @@ mod tests {
         apply_nearby_ride_event(&mut requests, "ride.unavailable", "not json at all");
 
         assert!(requests.is_empty());
+    }
+
+    fn sample_tracked_ride() -> Ride {
+        Ride {
+            id: 1,
+            status: RideStatus::Requested,
+            origin: Coordinates {
+                latitude: 4.710989,
+                longitude: -74.072092,
+            },
+            destination: Coordinates {
+                latitude: 4.698,
+                longitude: -74.061,
+            },
+            distance_meters: 7421,
+            duration_seconds: 842,
+            currency: "COP".to_string(),
+            estimated_fare: 8850,
+            driver: None,
+            requested_at: "2026-07-31T14:03:21+00:00".to_string(),
+            started_at: None,
+            completed_at: None,
+            final_fare: None,
+            payment: None,
+        }
+    }
+
+    #[test]
+    fn apply_ride_tracking_event_updates_the_status_on_status_changed() {
+        let mut tracking = RideTracking::new(sample_tracked_ride());
+
+        apply_ride_tracking_event(
+            &mut tracking,
+            "status.changed",
+            r#"{"status": "accepted", "driver_id": 42}"#,
+        );
+
+        assert_eq!(tracking.ride.status, RideStatus::Accepted);
+    }
+
+    #[test]
+    fn apply_ride_tracking_event_assigns_a_new_driver_by_id_without_a_name() {
+        let mut tracking = RideTracking::new(sample_tracked_ride());
+
+        apply_ride_tracking_event(
+            &mut tracking,
+            "status.changed",
+            r#"{"status": "accepted", "driver_id": 42}"#,
+        );
+
+        assert_eq!(
+            tracking.ride.driver,
+            Some(RideDriver {
+                id: 42,
+                name: String::new(),
+            })
+        );
+    }
+
+    #[test]
+    fn apply_ride_tracking_event_keeps_the_known_driver_name_when_the_id_matches() {
+        let mut ride = sample_tracked_ride();
+        ride.status = RideStatus::Accepted;
+        ride.driver = Some(RideDriver {
+            id: 42,
+            name: "Carlos Perez".to_string(),
+        });
+        let mut tracking = RideTracking::new(ride);
+
+        apply_ride_tracking_event(
+            &mut tracking,
+            "status.changed",
+            r#"{"status": "in_progress", "driver_id": 42}"#,
+        );
+
+        assert_eq!(
+            tracking.ride.driver,
+            Some(RideDriver {
+                id: 42,
+                name: "Carlos Perez".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn apply_ride_tracking_event_clears_the_driver_when_the_event_carries_none() {
+        let mut ride = sample_tracked_ride();
+        ride.driver = Some(RideDriver {
+            id: 42,
+            name: "Carlos Perez".to_string(),
+        });
+        let mut tracking = RideTracking::new(ride);
+
+        apply_ride_tracking_event(
+            &mut tracking,
+            "status.changed",
+            r#"{"status": "requested", "driver_id": null}"#,
+        );
+
+        assert_eq!(tracking.ride.driver, None);
+    }
+
+    #[test]
+    fn apply_ride_tracking_event_updates_the_driver_location_on_location_updated() {
+        let mut ride = sample_tracked_ride();
+        ride.driver = Some(RideDriver {
+            id: 42,
+            name: "Carlos Perez".to_string(),
+        });
+        let mut tracking = RideTracking::new(ride);
+
+        apply_ride_tracking_event(
+            &mut tracking,
+            "location.updated",
+            r#"{"driver_id": 42, "latitude": 4.71, "longitude": -74.07}"#,
+        );
+
+        assert_eq!(
+            tracking.driver_location,
+            Some(Coordinates {
+                latitude: 4.71,
+                longitude: -74.07,
+            })
+        );
+    }
+
+    #[test]
+    fn apply_ride_tracking_event_ignores_location_from_an_unassigned_driver() {
+        let mut ride = sample_tracked_ride();
+        ride.driver = Some(RideDriver {
+            id: 42,
+            name: "Carlos Perez".to_string(),
+        });
+        let mut tracking = RideTracking::new(ride);
+
+        apply_ride_tracking_event(
+            &mut tracking,
+            "location.updated",
+            r#"{"driver_id": 99, "latitude": 4.71, "longitude": -74.07}"#,
+        );
+
+        assert_eq!(tracking.driver_location, None);
+    }
+
+    #[test]
+    fn apply_ride_tracking_event_ignores_an_unknown_event_name() {
+        let mut tracking = RideTracking::new(sample_tracked_ride());
+
+        apply_ride_tracking_event(&mut tracking, "pusher_internal:subscription_succeeded", "");
+
+        assert_eq!(tracking, RideTracking::new(sample_tracked_ride()));
+    }
+
+    #[test]
+    fn apply_ride_tracking_event_ignores_malformed_data_without_panicking() {
+        let mut tracking = RideTracking::new(sample_tracked_ride());
+
+        apply_ride_tracking_event(&mut tracking, "status.changed", "not json at all");
+        apply_ride_tracking_event(&mut tracking, "location.updated", "not json at all");
+
+        assert_eq!(tracking, RideTracking::new(sample_tracked_ride()));
     }
 }

--- a/crates/moto_ui/src/map.rs
+++ b/crates/moto_ui/src/map.rs
@@ -58,7 +58,10 @@ const MAP_INIT_TEMPLATE: &str = r#"
         if (!el) {
             return;
         }
+        window.__motoyaMaps = window.__motoyaMaps || {};
         var map = L.map(el).setView([__MOTOYA_LAT__, __MOTOYA_LNG__], __MOTOYA_ZOOM__);
+        window.__motoyaMaps["__MOTOYA_MAP_ID__"] = map;
+        map.__motoyaMarkers = [];
         L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
             maxZoom: 19,
             attribution: "&copy; OpenStreetMap contributors",
@@ -66,6 +69,31 @@ const MAP_INIT_TEMPLATE: &str = r#"
         __MOTOYA_MARKERS__
         __MOTOYA_CLICK_HANDLER__
     });
+})();
+"#;
+
+/// Actualiza un mapa ya inicializado (centro/zoom y marcadores) sin volver a
+/// llamar `L.map(el)` — Leaflet no permite reinicializar el mismo elemento
+/// del DOM dos veces ("Map container is already initialized"). Se usa
+/// cuando `MapView` vuelve a renderizar con props distintas despues del
+/// primer montaje (issue #20: tracking en tiempo real de la ubicacion del
+/// conductor), la reactividad que `.claude/STANDARDS.md` deja pendiente
+/// desde el issue #4. Busca la instancia guardada en
+/// `window.__motoyaMaps` por `MAP_INIT_TEMPLATE`; si todavia no existe
+/// (efecto de actualizacion disparado antes de que termine el `ready()`
+/// inicial) no hace nada, sin lanzar un error.
+const MAP_UPDATE_TEMPLATE: &str = r#"
+(function () {
+    var map = window.__motoyaMaps && window.__motoyaMaps["__MOTOYA_MAP_ID__"];
+    if (!map) {
+        return;
+    }
+    map.setView([__MOTOYA_LAT__, __MOTOYA_LNG__], __MOTOYA_ZOOM__);
+    (map.__motoyaMarkers || []).forEach(function (marker) {
+        map.removeLayer(marker);
+    });
+    map.__motoyaMarkers = [];
+    __MOTOYA_MARKERS__
 })();
 "#;
 
@@ -99,8 +127,11 @@ impl MapMarker {
             None => String::new(),
         };
 
+        // Se registra en `map.__motoyaMarkers` (no solo `.addTo(map)`) para
+        // que `MAP_UPDATE_TEMPLATE` pueda encontrar y quitar los marcadores
+        // de la vuelta anterior antes de agregar los nuevos.
         format!(
-            "L.marker([{lat}, {lng}]){popup}.addTo(map);",
+            "map.__motoyaMarkers.push(L.marker([{lat}, {lng}]){popup}.addTo(map));",
             lat = self.lat,
             lng = self.lng,
         )
@@ -139,6 +170,31 @@ fn build_init_script(
         .replace("__MOTOYA_CLICK_HANDLER__", click_handler_js)
 }
 
+/// Contraparte de `build_init_script` para una vuelta de renderizado
+/// posterior al montaje (ver `MAP_UPDATE_TEMPLATE`): recalcula centro,
+/// zoom y marcadores sobre la instancia de Leaflet ya creada, sin tocar el
+/// tile layer ni el listener de click, que no cambian entre renders.
+fn build_update_script(
+    id: &str,
+    center_lat: f64,
+    center_lng: f64,
+    zoom: u8,
+    markers: &[MapMarker],
+) -> String {
+    let markers_js: String = markers
+        .iter()
+        .map(MapMarker::to_js_statement)
+        .collect::<Vec<_>>()
+        .join("\n    ");
+
+    MAP_UPDATE_TEMPLATE
+        .replace("__MOTOYA_MAP_ID__", id)
+        .replace("__MOTOYA_LAT__", &center_lat.to_string())
+        .replace("__MOTOYA_LNG__", &center_lng.to_string())
+        .replace("__MOTOYA_ZOOM__", &zoom.to_string())
+        .replace("__MOTOYA_MARKERS__", &markers_js)
+}
+
 /// Payload que manda `dioxus.send` desde `CLICK_HANDLER_TEMPLATE`.
 #[derive(Debug, Clone, Copy, PartialEq, serde::Deserialize)]
 struct MapClickPayload {
@@ -163,12 +219,15 @@ fn next_map_id() -> String {
 /// Sigue siendo agnostico de dominio — no sabe que representa el punto
 /// elegido, eso lo decide quien use `MapView`.
 ///
-/// Limitacion conocida (documentada, no un descuido): la inicializacion
-/// corre una sola vez al montar el componente, igual que el patron ya usado
-/// en `App::hydrate` (ver `moto_ui/src/lib.rs`). Si `center`/`zoom`/
-/// `markers` cambian en un remount posterior, el mapa no se actualiza
-/// reactivamente todavia — eso queda para la historia que consuma esto con
-/// tracking en tiempo real (fuera de alcance de este issue).
+/// La primera vez que se monta, `L.map(el)` crea la instancia de Leaflet
+/// (ver `MAP_INIT_TEMPLATE`) y la guarda en `window.__motoyaMaps`. Cada vez
+/// que el componente vuelve a renderizar con `center`/`zoom`/`markers`
+/// distintos, en cambio, se reusa esa misma instancia y solo se actualiza
+/// la vista y los marcadores (`MAP_UPDATE_TEMPLATE`, via
+/// `build_update_script`) — Leaflet no permite un segundo `L.map(el)`
+/// sobre el mismo elemento. Esto es lo que dejaba pendiente
+/// `.claude/STANDARDS.md` desde el issue #4, resuelto en el #20 para poder
+/// mover el marcador del conductor en el mapa sin recargar la pantalla.
 #[component]
 pub fn MapView(
     center_lat: f64,
@@ -178,28 +237,48 @@ pub fn MapView(
     #[props(default)] on_click: Option<EventHandler<(f64, f64)>>,
 ) -> Element {
     let map_id = use_hook(next_map_id);
+    // Distingue el primer render (crea el mapa) de los siguientes (lo
+    // actualiza). `peek()` a proposito, no una lectura reactiva: leerlo
+    // "de verdad" suscribiria este mismo efecto a sus propios cambios y lo
+    // haria correr una segunda vez de inmediato tras `initialized.set(true)`.
+    let mut initialized = use_signal(|| false);
 
     {
         let map_id = map_id.clone();
-        use_effect(move || {
-            let script = build_init_script(
-                &map_id,
-                center_lat,
-                center_lng,
-                zoom,
-                &markers,
-                on_click.is_some(),
-            );
-            let mut eval = document::eval(&script);
+        use_effect(use_reactive(
+            (&center_lat, &center_lng, &zoom, &markers),
+            move |(center_lat, center_lng, zoom, markers)| {
+                let is_first_run = !*initialized.peek();
 
-            if let Some(on_click) = on_click {
-                spawn(async move {
-                    while let Ok(payload) = eval.recv::<MapClickPayload>().await {
-                        on_click.call((payload.lat, payload.lng));
-                    }
-                });
-            }
-        });
+                let script = if is_first_run {
+                    initialized.set(true);
+                    build_init_script(
+                        &map_id,
+                        center_lat,
+                        center_lng,
+                        zoom,
+                        &markers,
+                        on_click.is_some(),
+                    )
+                } else {
+                    build_update_script(&map_id, center_lat, center_lng, zoom, &markers)
+                };
+                let mut eval = document::eval(&script);
+
+                // El listener de click solo tiene sentido atado al `eval`
+                // que corrio `CLICK_HANDLER_TEMPLATE` (el de la
+                // inicializacion): las vueltas de actualizacion no vuelven
+                // a registrar el handler, asi que su `eval` nunca recibe
+                // nada por `dioxus.send`.
+                if is_first_run && let Some(on_click) = on_click {
+                    spawn(async move {
+                        while let Ok(payload) = eval.recv::<MapClickPayload>().await {
+                            on_click.call((payload.lat, payload.lng));
+                        }
+                    });
+                }
+            },
+        ));
     }
 
     rsx! {
@@ -260,8 +339,10 @@ mod tests {
         let script = build_init_script("motoya-map-1", 4.71, -74.07, 13, &markers, false);
 
         assert_eq!(script.matches("L.marker(").count(), 2);
-        assert!(script.contains("L.marker([4.71, -74.07]).bindPopup(\"Origen\").addTo(map);"));
-        assert!(script.contains("L.marker([4.72, -74.08]).addTo(map);"));
+        assert!(script.contains(
+            "map.__motoyaMarkers.push(L.marker([4.71, -74.07]).bindPopup(\"Origen\").addTo(map));"
+        ));
+        assert!(script.contains("map.__motoyaMarkers.push(L.marker([4.72, -74.08]).addTo(map));"));
     }
 
     #[test]
@@ -302,5 +383,37 @@ mod tests {
 
         assert_ne!(first, second);
         assert!(first.starts_with("motoya-map-"));
+    }
+
+    #[test]
+    fn build_update_script_looks_up_the_existing_map_instance_by_id() {
+        let script = build_update_script("motoya-map-0", 4.71, -74.07, 15, &[]);
+
+        assert!(script.contains(r#"window.__motoyaMaps && window.__motoyaMaps["motoya-map-0"]"#));
+        assert!(script.contains("setView([4.71, -74.07], 15)"));
+    }
+
+    #[test]
+    fn build_update_script_does_not_recreate_the_map_or_the_tile_layer() {
+        let script = build_update_script("motoya-map-0", 0.0, 0.0, 13, &[]);
+
+        assert!(!script.contains("L.map("));
+        assert!(!script.contains("L.tileLayer("));
+        assert!(!script.contains("map.on(\"click\""));
+    }
+
+    #[test]
+    fn build_update_script_removes_the_previous_markers_before_adding_new_ones() {
+        let markers = vec![MapMarker {
+            lat: 4.72,
+            lng: -74.08,
+            label: None,
+        }];
+
+        let script = build_update_script("motoya-map-0", 4.71, -74.07, 13, &markers);
+
+        assert!(script.contains("map.__motoyaMarkers || []).forEach"));
+        assert!(script.contains("map.removeLayer(marker);"));
+        assert!(script.contains("map.__motoyaMarkers.push(L.marker([4.72, -74.08]).addTo(map));"));
     }
 }

--- a/crates/moto_ui/src/screens/ride_estimate.rs
+++ b/crates/moto_ui/src/screens/ride_estimate.rs
@@ -1,5 +1,5 @@
-//! Pantalla de tarifa estimada y solicitud de viaje (pasajero) — issues #13
-//! y #14.
+//! Pantalla de tarifa estimada, solicitud de viaje y seguimiento en tiempo
+//! real (pasajero) — issues #13, #14 y #20.
 //!
 //! Consume `POST /api/v1/rides/estimate` (`ApiClient::estimate_ride`) para la
 //! tarifa estimada, sin solicitar nada todavia. Una vez que hay una
@@ -21,16 +21,44 @@
 //! a `accepted` este boton deja de ofrecerse — cancelar un viaje ya aceptado
 //! es la historia "Cancelar un viaje aceptado (pasajero)" (#21), fuera de
 //! alcance aca.
+//!
+//! Mientras el viaje siga activo (`requested`, `accepted` o `in_progress`),
+//! `RideTrackingPanel` (issue #20) pide el estado actual por
+//! `GET /api/v1/rides/{ride}` (`ApiClient::get_ride`) y se suscribe al canal
+//! privado `ride.{id}` para el resto: cambios de estado (`status.changed`) y
+//! la posicion del conductor asignado (`location.updated`, publicada por
+//! `ShareLocationPanel` del lado del conductor, issue #19). Mismo patron de
+//! sondeo/reconexion que `NearbyRidesList` (`nearby_rides.rs`); los eventos
+//! se aplican con `moto_core::models::apply_ride_tracking_event`, logica
+//! pura testeada aparte de Dioxus. El mapa reusa `MapView` (issue #4), que
+//! desde esta historia actualiza sus marcadores reactivamente en vez de solo
+//! al montarse (ver `moto_ui/src/map.rs`).
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use dioxus::prelude::*;
-use moto_core::api::{ApiClient, CancelRideError, EstimateRideError, RequestRideError};
-use moto_core::models::{Coordinates, Ride, RideEstimate, RideStatus};
+use futures_timer::Delay;
+use moto_core::api::{
+    ApiClient, CancelRideError, EstimateRideError, GetRideError, RequestRideError,
+};
+use moto_core::models::{
+    Coordinates, Ride, RideEstimate, RideStatus, RideTracking, apply_ride_tracking_event,
+};
+use moto_core::realtime::{
+    ConnectionState, PollAction, RealtimeClient, RealtimeConfig, SubscribeFailureAction,
+    decide_poll_action, decide_subscribe_failure,
+};
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
 
 use crate::map::{MapMarker, MapView};
+
+/// Intervalo entre sondeos de `RealtimeClient::poll_events` para el canal
+/// `ride.{id}` (issue #20) — mismo valor y mismo motivo que el
+/// `POLL_INTERVAL` de `NearbyRidesList` (`nearby_rides.rs`): el transporte
+/// no avisa solo cuando llega un frame nuevo.
+const RIDE_TRACKING_POLL_INTERVAL: Duration = Duration::from_millis(700);
 
 /// Centro inicial del mapa mientras no exista geolocalizacion del
 /// dispositivo (fuera de alcance de este issue): Bogota, el mismo punto que
@@ -244,6 +272,16 @@ pub fn RideEstimateScreen() -> Element {
     };
 
     if let Some(ride) = requested_ride() {
+        // Mientras el viaje sigue activo hay algo que seguir en tiempo real
+        // (issue #20): una vez `completed`/`cancelled` no queda nada mas que
+        // rastrear, y `RideTrackingPanel` se desmonta (Dioxus cancela su
+        // loop de sondeo, mismo criterio que `ShareLocationPanel` en
+        // `nearby_rides.rs`).
+        let is_active = matches!(
+            ride.status,
+            RideStatus::Requested | RideStatus::Accepted | RideStatus::InProgress
+        );
+
         return rsx! {
             div { class: "ride-estimate-screen",
                 h2 { "Viaje solicitado" }
@@ -270,6 +308,14 @@ pub fn RideEstimateScreen() -> Element {
                     }
                     if let Some(err) = cancel_error() {
                         p { class: "ride-cancel-error", role: "alert", "{err}" }
+                    }
+                }
+                if is_active {
+                    RideTrackingPanel {
+                        initial_ride: ride.clone(),
+                        on_ride_updated: move |updated: Ride| {
+                            requested_ride.set(Some(updated));
+                        },
                     }
                 }
             }
@@ -347,11 +393,234 @@ pub fn RideEstimateScreen() -> Element {
     }
 }
 
+/// Estado de la conexion en tiempo real que muestra esta pantalla — mismo
+/// criterio que `nearby_rides::RealtimeStatus`: agrega `Unavailable` a
+/// `moto_core::realtime::ConnectionState` y no expone el numero de intento
+/// de reconexion, que no le sirve al pasajero.
+#[derive(Debug, Clone, PartialEq)]
+enum RideRealtimeStatus {
+    Connecting,
+    Connected,
+    Reconnecting,
+    Unavailable(String),
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct RideTrackingPanelProps {
+    initial_ride: Ride,
+    on_ride_updated: EventHandler<Ride>,
+}
+
+/// Seguimiento en tiempo real de un viaje activo (issue #20).
+///
+/// Al montarse vuelve a pedir el viaje por `GET /api/v1/rides/{ride}`: no
+/// confia solo en `initial_ride` (el estado que ya tenia `RideEstimateScreen`
+/// de cuando lo solicito), que puede haber quedado desactualizado si esta
+/// pantalla se reabrio despues de un tiempo. Ese fetch no bloquea el resto
+/// de la pantalla si falla por algo que no sea la sesion — ya hay algo que
+/// mostrar con `initial_ride`, y el canal en tiempo real puede seguir
+/// aportando actualizaciones igual.
+///
+/// Se suscribe al canal privado `ride.{id}` con el mismo patron de
+/// sondeo/reconexion que `NearbyRidesList` (`nearby_rides.rs`): la decision
+/// de cuando suscribirse, reconectar o cortar el loop vive en
+/// `moto_core::realtime` (`decide_poll_action`, `decide_subscribe_failure`),
+/// testeada aparte. Cada `status.changed` se le avisa al padre via
+/// `on_ride_updated` para que decida si sigue ofreciendo "Cancelar
+/// solicitud" (issue #15) y que texto de estado mostrar; `location.updated`
+/// solo mueve el marcador del conductor en el mapa de esta misma pantalla.
+#[component]
+fn RideTrackingPanel(props: RideTrackingPanelProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+    let realtime_config = use_context::<RealtimeConfig>();
+
+    let ride_id = props.initial_ride.id;
+    let on_ride_updated = props.on_ride_updated;
+
+    let mut tracking = use_signal(|| RideTracking::new(props.initial_ride.clone()));
+    let mut status = use_signal(|| RideRealtimeStatus::Connecting);
+    // Mismo criterio que el resto de los loops de sondeo de esta app: evita
+    // levantar un segundo loop si el efecto se vuelve a disparar (p.ej.
+    // porque `initial_ride` cambio de valor en un re-render).
+    let mut started = use_signal(|| false);
+
+    use_effect(move || {
+        if started() {
+            return;
+        }
+        started.set(true);
+
+        let Some(token) = session.token() else {
+            status.set(RideRealtimeStatus::Unavailable(
+                "La sesion expiro. Inicia sesion de nuevo.".to_string(),
+            ));
+            return;
+        };
+
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+        let realtime_config = realtime_config.clone();
+
+        spawn(async move {
+            let mut current_token = token;
+
+            match api_client.get_ride(&current_token, ride_id).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed.clone(), storage.as_ref());
+                        current_token = refreshed;
+                    }
+                    tracking.with_mut(|t| t.ride = fetch.data.clone());
+                    on_ride_updated.call(fetch.data);
+                }
+                Err(GetRideError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                    return;
+                }
+                Err(_) => {}
+            }
+
+            let Some(ws_url) = realtime_config.ws_url.clone() else {
+                status.set(RideRealtimeStatus::Unavailable(
+                    "El tiempo real no esta configurado en este entorno.".to_string(),
+                ));
+                return;
+            };
+
+            let mut client = match RealtimeClient::connect(api_client, ws_url) {
+                Ok(client) => client,
+                Err(err) => {
+                    status.set(RideRealtimeStatus::Unavailable(err));
+                    return;
+                }
+            };
+            let mut subscribed = false;
+            let bare_channel = format!("ride.{ride_id}");
+            let full_channel = format!("private-{bare_channel}");
+
+            loop {
+                for event in client.poll_events() {
+                    if event.channel != full_channel {
+                        continue;
+                    }
+
+                    let is_status_change = event.event == "status.changed";
+                    tracking.with_mut(|t| {
+                        apply_ride_tracking_event(t, &event.event, &event.data);
+                    });
+                    if is_status_change {
+                        on_ride_updated.call(tracking.read().ride.clone());
+                    }
+                }
+
+                let state = client.state();
+                match &state {
+                    ConnectionState::Connecting => status.set(RideRealtimeStatus::Connecting),
+                    ConnectionState::Reconnecting { .. } => {
+                        status.set(RideRealtimeStatus::Reconnecting)
+                    }
+                    ConnectionState::Connected => {}
+                }
+
+                let decision = decide_poll_action(&state, subscribed);
+                subscribed = decision.subscribed;
+
+                match decision.action {
+                    PollAction::Wait => {}
+                    PollAction::Subscribe => {
+                        match client.subscribe(&current_token, &bare_channel).await {
+                            Ok(()) => {
+                                subscribed = true;
+                                status.set(RideRealtimeStatus::Connected);
+                            }
+                            Err(err) => {
+                                status.set(RideRealtimeStatus::Unavailable(err.to_string()));
+                                match decide_subscribe_failure(&err) {
+                                    SubscribeFailureAction::Retry => {}
+                                    SubscribeFailureAction::LogoutAndStop => {
+                                        session.logout(storage.as_ref());
+                                        break;
+                                    }
+                                    SubscribeFailureAction::Stop => break,
+                                }
+                            }
+                        }
+                    }
+                    // `RealtimeClient` no reconecta solo: el `Delay` de mas
+                    // abajo ya espacia estos intentos, mismo criterio que
+                    // `NearbyRidesList`.
+                    PollAction::Reconnect => {
+                        if let Err(err) = client.reconnect() {
+                            status.set(RideRealtimeStatus::Unavailable(err));
+                            break;
+                        }
+                    }
+                }
+
+                Delay::new(RIDE_TRACKING_POLL_INTERVAL).await;
+            }
+        });
+    });
+
+    let current = tracking.read();
+    let mut markers = vec![
+        MapMarker {
+            lat: current.ride.origin.latitude,
+            lng: current.ride.origin.longitude,
+            label: Some("Origen".to_string()),
+        },
+        MapMarker {
+            lat: current.ride.destination.latitude,
+            lng: current.ride.destination.longitude,
+            label: Some("Destino".to_string()),
+        },
+    ];
+    // El mapa sigue al conductor cuando ya se conoce su posicion: es lo que
+    // el pasajero quiere ver para saber cuando va a llegar (criterio de
+    // aceptacion del issue). Sin ubicacion todavia (viaje `requested`, o
+    // recien `accepted` antes del primer `location.updated`), centra en el
+    // origen.
+    let (center_lat, center_lng) = if let Some(location) = current.driver_location {
+        markers.push(MapMarker {
+            lat: location.latitude,
+            lng: location.longitude,
+            label: Some("Tu conductor".to_string()),
+        });
+        (location.latitude, location.longitude)
+    } else {
+        (current.ride.origin.latitude, current.ride.origin.longitude)
+    };
+    drop(current);
+
+    rsx! {
+        div { class: "ride-tracking-panel",
+            match status() {
+                RideRealtimeStatus::Connecting => rsx! {
+                    p { class: "ride-tracking-status", "Conectando..." }
+                },
+                RideRealtimeStatus::Reconnecting => rsx! {
+                    p { class: "ride-tracking-status", "Reconectando..." }
+                },
+                RideRealtimeStatus::Unavailable(message) => rsx! {
+                    p { class: "ride-tracking-error", role: "alert", "{message}" }
+                },
+                RideRealtimeStatus::Connected => rsx! {
+                    p { class: "ride-tracking-status", "Seguimiento en vivo." }
+                },
+            }
+            div { class: "ride-tracking-map", style: "height: 320px;",
+                MapView { center_lat, center_lng, markers }
+            }
+        }
+    }
+}
+
 /// Texto para el pasajero segun el estado del viaje recien solicitado
 /// (`Ride::status`). Justo despues de `POST /api/v1/rides` el viaje siempre
-/// nace `requested`; los demas casos quedan cubiertos para cuando esta misma
-/// pantalla se reutilice con datos de un viaje ya en curso (historia #20,
-/// fuera de alcance de #14).
+/// nace `requested`; los demas casos son los que reporta `RideTrackingPanel`
+/// (issue #20) a medida que el viaje avanza.
 fn ride_status_label(status: RideStatus) -> &'static str {
     match status {
         RideStatus::Requested => "Esperando a que un conductor lo acepte.",


### PR DESCRIPTION
Closes #20

## Que hace

El pasajero ve el estado y la ubicacion del conductor en tiempo real
mientras su viaje sigue activo (`requested`, `accepted` o `in_progress`).

- `ApiClient::get_ride` (`GET /api/v1/rides/{ride}`, `moto_core/src/api.rs`):
  estado inicial del viaje al abrir la pantalla o al reconectar, con el
  mismo patron de reintento/refresh de token que el resto del cliente;
  `403`/`404` nunca se reintentan.
- `RideTracking` + `apply_ride_tracking_event` (`moto_core/src/models.rs`):
  logica pura que aplica los eventos del canal privado `ride.{id}` —
  `status.changed` (nuevo estado + conductor asignado) y `location.updated`
  (posicion del conductor, solo si coincide con el conductor asignado al
  viaje) — testeada sin Dioxus ni socket real.
- `RideTrackingPanel` (`moto_ui/src/screens/ride_estimate.rs`): componente
  que pide el estado inicial, se suscribe al canal `ride.{id}` con el mismo
  patron de sondeo/reconexion que `NearbyRidesList`, y muestra el mapa con
  el marcador del conductor. Se desmonta cuando el viaje ya no esta activo.
- `MapView` (`moto_ui/src/map.rs`) ahora actualiza reactivamente centro,
  zoom y marcadores sobre la misma instancia de Leaflet en vez de solo
  inicializarse una vez — lo que dejaba pendiente el issue #4 y que esta
  historia necesita para mover el marcador del conductor sin recargar la
  pantalla.

## Como se probo

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude mobile` (181 tests en verde, incluye los
  nuevos de `apply_ride_tracking_event` y `build_update_script`)
- `cargo build --package web --target wasm32-unknown-unknown` (mismo check
  que `build-web` en CI)

## Decisiones y riesgos

- Fallback no realtime explicito: si el fetch inicial a `GET /api/v1/rides/{ride}`
  falla por algo que no sea la sesion, la pantalla sigue mostrando
  `initial_ride` y el canal en tiempo real puede seguir aportando
  actualizaciones igual.
- Si llega un `status.changed` con un `driver_id` nuevo que la pantalla no
  conocia todavia, se guarda con nombre vacio en vez de inventarlo; se
  completa en el proximo fetch HTTP tras reconectar.
- Encontre este trabajo ya iniciado como cambios sin commitear en `main`
  (no de esta corrida) cubriendo casi todo el alcance del issue; lo retome,
  corregi dos errores de compilacion que tenia (`!Signal<bool>` sin `Not` y
  un `move` que consumia `RealtimeConfig` dentro de un `use_effect` que se
  puede volver a invocar) y lo deje en verde en los cuatro checks de arriba.