### PR TITLE
feat(#22): cancelar un viaje aceptado (conductor)

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -621,8 +621,8 @@ impl std::error::Error for RequestRideError {}
 /// Fallos posibles de `POST /api/v1/rides/{ride}/cancel` (issue #15).
 ///
 /// El mismo endpoint sirve tanto para que el pasajero cancele (historias
-/// #16/#22) como para que el conductor asignado libere el viaje (historia
-/// #23) — el cliente no distingue esos dos casos, los resuelve el backend
+/// #15/#21) como para que el conductor asignado libere el viaje (historia
+/// #22) — el cliente no distingue esos dos casos, los resuelve el backend
 /// segun quien llama (ver `openapi.yaml`). `Validation` cubre que el viaje ya
 /// no este en un estado cancelable (`in_progress`, `completed` o ya
 /// `cancelled`).

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -258,7 +258,7 @@ pub struct Ride {
 /// respuesta de `POST /api/v1/rides/{ride}/cancel` (issue #15).
 ///
 /// `cancellation_fee_applies` esta ausente cuando quien cancela es el
-/// conductor asignado (historia #23, fuera de alcance de #15): ese caso no
+/// conductor asignado (historia #22, fuera de alcance de #15): ese caso no
 /// cancela el viaje, solo lo devuelve al pool sin conductor. `#[serde(flatten)]`
 /// reutiliza `Ride` en vez de repetir sus campos.
 #[derive(Debug, Clone, Deserialize, PartialEq)]

--- a/crates/moto_ui/src/screens/nearby_rides.rs
+++ b/crates/moto_ui/src/screens/nearby_rides.rs
@@ -30,13 +30,25 @@
 //! saca de la lista con un mensaje explicito en vez de un error generico, tal
 //! como pide el criterio de aceptacion del issue.
 //!
-//! Mientras el viaje aceptado siga en `accepted`, se ofrece un boton
-//! "Iniciar viaje" que llama a `POST /api/v1/rides/{ride}/start`
+//! Mientras el viaje aceptado siga en `accepted`, se ofrecen dos botones:
+//! "Iniciar viaje", que llama a `POST /api/v1/rides/{ride}/start`
 //! (`ApiClient::start_ride`, issue #18) — la condicion de estado es lo que
 //! hace que el boton no este disponible si el viaje ya paso a otro estado
 //! (criterio de aceptacion del issue). Al iniciar con exito, la pantalla
 //! reemplaza el viaje en pantalla por la version devuelta por el backend
 //! (ahora `in_progress`, con `started_at`) en vez de solo esconder el boton.
+//! Y "Cancelar viaje", que llama a `POST /api/v1/rides/{ride}/cancel`
+//! (`ApiClient::cancel_ride`, issue #22) para que el conductor libere un
+//! viaje que acepto pero todavia no inicio. A diferencia de cuando cancela
+//! el pasajero (issues #15/#21), aqui el viaje no queda `cancelled`: vuelve a
+//! `requested` sin conductor asignado, para que otro conductor pueda
+//! tomarlo (`RideCancellation::cancellation_fee_applies` llega `None` en
+//! este caso, ver `moto_core::models`), asi que esta pantalla simplemente
+//! deja de mostrarlo como "su" viaje aceptado y vuelve a la lista de
+//! solicitudes cercanas, sin un panel de resultado como el de
+//! `RideEstimateScreen`. Un viaje `in_progress` ya no se puede cancelar por
+//! este endpoint segun `openapi.yaml` (solo completarse, historia #23), asi
+//! que el boton no se ofrece en ese estado.
 //!
 //! Mientras el viaje siga en `in_progress`, `ShareLocationPanel` publica
 //! periodicamente la posicion del conductor con
@@ -57,8 +69,8 @@ use std::time::Duration;
 use dioxus::prelude::*;
 use futures_timer::Delay;
 use moto_core::api::{
-    AcceptRideError, ApiClient, AuthenticatedRequestError, GetVehicleError, ShareRideLocationError,
-    StartRideError,
+    AcceptRideError, ApiClient, AuthenticatedRequestError, CancelRideError, GetVehicleError,
+    ShareRideLocationError, StartRideError,
 };
 use moto_core::location::{LocationError, LocationProvider};
 use moto_core::models::{NearbyRideRequest, Ride, RideStatus, apply_nearby_ride_event};
@@ -335,6 +347,12 @@ fn NearbyRidesList(props: NearbyRidesListProps) -> Element {
                                 accepted_ride.set(Some(started));
                             },
                         }
+                        CancelAcceptedRideButton {
+                            ride_id: ride.id,
+                            on_cancelled: move |_| {
+                                accepted_ride.set(None);
+                            },
+                        }
                     } else if ride.status == RideStatus::InProgress {
                         ShareLocationPanel { ride_id: ride.id }
                     }
@@ -526,6 +544,82 @@ fn StartRideButton(props: StartRideButtonProps) -> Element {
             }
             if let Some(message) = error() {
                 p { class: "nearby-ride-start-error", role: "alert", "{message}" }
+            }
+        }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct CancelAcceptedRideButtonProps {
+    ride_id: u64,
+    on_cancelled: EventHandler<()>,
+}
+
+/// Boton "Cancelar viaje" del viaje aceptado, antes de iniciarlo (issue
+/// #22). Llama a `ApiClient::cancel_ride`, el mismo endpoint que usa el
+/// pasajero (issues #15/#21) — el backend decide segun quien llama, ver el
+/// comentario de modulo mas arriba. Al tener exito no hay nada que mostrar
+/// (el viaje ya no es "suyo"), asi que solo avisa al padre para que vuelva a
+/// la lista; el estado de carga/error queda aparte, igual que
+/// `StartRideButton`, para no afectar al resto de la pantalla mientras la
+/// llamada esta en curso.
+#[component]
+fn CancelAcceptedRideButton(props: CancelAcceptedRideButtonProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut is_cancelling = use_signal(|| false);
+    let mut error = use_signal(|| None::<String>);
+
+    let ride_id = props.ride_id;
+    let on_cancelled = props.on_cancelled;
+
+    let on_cancel_click = move |_| {
+        let Some(token) = session.token() else {
+            return;
+        };
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_cancelling.set(true);
+            error.set(None);
+
+            match api_client.cancel_ride(&token, ride_id).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    on_cancelled.call(());
+                }
+                Err(CancelRideError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    error.set(Some(err.to_string()));
+                }
+            }
+
+            is_cancelling.set(false);
+        });
+    };
+
+    rsx! {
+        div { class: "nearby-ride-cancel",
+            button {
+                r#type: "button",
+                class: "nearby-ride-cancel-button",
+                disabled: is_cancelling(),
+                onclick: on_cancel_click,
+                if is_cancelling() {
+                    "Cancelando..."
+                } else {
+                    "Cancelar viaje"
+                }
+            }
+            if let Some(message) = error() {
+                p { class: "nearby-ride-cancel-error", role: "alert", "{message}" }
             }
         }
     }


### PR DESCRIPTION
Closes #22

## Qué hace

Agrega un botón "Cancelar viaje" en `NearbyRidesScreen` para que el
conductor pueda liberar un viaje que aceptó pero todavía no inició
(`ride.status == Accepted`). Reutiliza `ApiClient::cancel_ride`
(`POST /api/v1/rides/{ride}/cancel`), ya implementado y testeado desde la
historia #15 — el mismo endpoint que usa el pasajero, con el backend
decidiendo el comportamiento según quién llama (`openapi.yaml`).

A diferencia de cuando cancela el pasajero (historias #15/#21), cuando
cancela el conductor el viaje **no** queda `cancelled`: vuelve a
`requested` sin conductor asignado, para que otro conductor pueda
tomarlo, y `RideCancellation::cancellation_fee_applies` llega `None`. Por
eso, al tener éxito, la pantalla simplemente deja de mostrarlo como "su"
viaje y vuelve a la lista de solicitudes cercanas (que sigue escuchando en
tiempo real sin interrupción), en vez de mostrar un panel de resultado
como hace `RideEstimateScreen` para el pasajero.

Un viaje `in_progress` no se puede cancelar por este endpoint según
`openapi.yaml` (solo completarse, historia #23), así que el botón no se
ofrece en ese estado — mismo criterio que ya aplica `RideEstimateScreen`.

De paso corrijo dos comentarios en `moto_core` (`api.rs`, `models.rs`) que
referenciaban mal el número de esta historia como "#23" (que en realidad
es "Completar el viaje") en vez de "#22".

## Cómo se probó

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude mobile` (170 tests en `moto_core`, 14
  en `moto_ui`, todos en verde — sin tests nuevos porque `cancel_ride` ya
  tiene cobertura HTTP mockeada desde #15, y aquí solo se conecta a la UI)
- `cargo build --package web --target wasm32-unknown-unknown` (mismo build
  que corre en CI)

## Decisiones y riesgos

- No se agregó un panel de "resultado de cancelación" como el de #21
  porque no aplica: no hay `cancellation_fee_applies` que mostrarle al
  conductor en este flujo (siempre `None` cuando cancela el conductor), y
  el viaje simplemente deja de estar asignado — no hay nada que confirmar
  aparte de volver a la lista.
- No se tocó CSS: no existe hoja de estilos para las clases
  `nearby-ride-*` existentes (`nearby-ride-start-button`, etc.), así que
  `nearby-ride-cancel-button` sigue el mismo patrón sin estilos propios.