### PR TITLE
feat(#23): completar el viaje (conductor)

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -762,6 +762,49 @@ impl std::fmt::Display for StartRideError {
 
 impl std::error::Error for StartRideError {}
 
+/// Fallos posibles de `POST /api/v1/rides/{ride}/complete` (issue #23).
+///
+/// Mismo reparto que `StartRideError`: `Forbidden` cubre tanto a un
+/// conductor distinto del asignado como al pasajero del viaje. `Validation`
+/// cubre que el viaje ya no este `in_progress` (todavia no arranco, ya se
+/// completo o se cancelo).
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompleteRideError {
+    Forbidden,
+    /// No existe ningun viaje con ese id.
+    NotFound,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for CompleteRideError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CompleteRideError::Forbidden => {
+                write!(f, "Este viaje no te pertenece.")
+            }
+            CompleteRideError::NotFound => write!(f, "El viaje ya no existe."),
+            CompleteRideError::Validation(body) => write!(f, "{}", body.message),
+            CompleteRideError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            CompleteRideError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            CompleteRideError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CompleteRideError {}
+
 /// Fallos posibles de `POST /api/v1/rides/{ride}/location` (issue #19).
 ///
 /// Mismo reparto que `StartRideError`: `Forbidden` cubre tanto a un
@@ -948,6 +991,14 @@ enum AcceptRideOutcome {
 }
 
 enum StartRideOutcome {
+    Success(Ride),
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    Validation(ApiErrorBody),
+}
+
+enum CompleteRideOutcome {
     Success(Ride),
     Unauthorized,
     Forbidden,
@@ -2166,6 +2217,96 @@ impl ApiClient {
                 Ok(StartRideOutcome::Validation(body))
             }
             other => Err(StartRideError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/rides/{ride}/complete` — issue #23. No manda body: como
+    /// `start_ride`, todo lo que decide esta operacion es el id del viaje y
+    /// quien la pide. Reintenta una vez con refresh de token ante un 401,
+    /// igual que `start_ride`; un 403 (viaje ajeno), 404 (no existe) o 422
+    /// (el viaje ya no esta `in_progress`) nunca se reintentan. La respuesta
+    /// exitosa trae el viaje con `completed_at`, `final_fare` y `payment` ya
+    /// resueltos por el backend (el cobro se dispara en la misma operacion).
+    pub async fn complete_ride(
+        &self,
+        token: &AuthToken,
+        ride_id: u64,
+    ) -> Result<AuthenticatedFetch<Ride>, CompleteRideError> {
+        match self
+            .post_complete_with_token(ride_id, &token.access_token)
+            .await?
+        {
+            CompleteRideOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            CompleteRideOutcome::Forbidden => return Err(CompleteRideError::Forbidden),
+            CompleteRideOutcome::NotFound => return Err(CompleteRideError::NotFound),
+            CompleteRideOutcome::Validation(body) => {
+                return Err(CompleteRideError::Validation(body));
+            }
+            CompleteRideOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| CompleteRideError::SessionExpired)?;
+
+        match self
+            .post_complete_with_token(ride_id, &renewed.access_token)
+            .await?
+        {
+            CompleteRideOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            CompleteRideOutcome::Forbidden => Err(CompleteRideError::Forbidden),
+            CompleteRideOutcome::NotFound => Err(CompleteRideError::NotFound),
+            CompleteRideOutcome::Validation(body) => Err(CompleteRideError::Validation(body)),
+            CompleteRideOutcome::Unauthorized => Err(CompleteRideError::SessionExpired),
+        }
+    }
+
+    async fn post_complete_with_token(
+        &self,
+        ride_id: u64,
+        access_token: &str,
+    ) -> Result<CompleteRideOutcome, CompleteRideError> {
+        let url = format!("{}/api/v1/rides/{}/complete", self.base_url, ride_id);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|err| CompleteRideError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<Ride> = response
+                .json()
+                .await
+                .map_err(|err| CompleteRideError::Network(err.to_string()))?;
+            return Ok(CompleteRideOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(CompleteRideOutcome::Unauthorized),
+            403 => Ok(CompleteRideOutcome::Forbidden),
+            404 => Ok(CompleteRideOutcome::NotFound),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| CompleteRideError::Network(err.to_string()))?;
+                Ok(CompleteRideOutcome::Validation(body))
+            }
+            other => Err(CompleteRideError::Unexpected(other)),
         }
     }
 
@@ -5076,6 +5217,203 @@ mod tests {
         let error = client.start_ride(&sample_token(), 1).await.unwrap_err();
 
         assert!(matches!(error, StartRideError::Network(_)));
+    }
+
+    fn sample_completed_ride_json() -> serde_json::Value {
+        let mut ride = sample_started_ride_json();
+        ride["status"] = serde_json::json!("completed");
+        ride["completed_at"] = serde_json::json!("2026-07-31T14:19:05+00:00");
+        ride["final_fare"] = serde_json::json!(9100);
+        ride["payment"] = serde_json::json!({ "status": "paid" });
+        ride
+    }
+
+    #[tokio::test]
+    async fn complete_ride_returns_the_completed_ride_with_final_fare_and_payment() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/complete"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": sample_completed_ride_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.complete_ride(&sample_token(), 1).await.unwrap();
+
+        assert_eq!(fetch.data.id, 1);
+        assert_eq!(fetch.data.status, crate::models::RideStatus::Completed);
+        assert_eq!(
+            fetch.data.completed_at,
+            Some("2026-07-31T14:19:05+00:00".to_string())
+        );
+        assert_eq!(fetch.data.final_fare, Some(9100));
+        assert_eq!(
+            fetch.data.payment.map(|payment| payment.status),
+            Some(crate::models::PaymentStatus::Paid)
+        );
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn complete_ride_returns_forbidden_on_403_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/complete"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.complete_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(error, CompleteRideError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn complete_ride_returns_not_found_on_404_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/999/complete"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "No query results for model [App\\Models\\Ride] 999.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .complete_ride(&sample_token(), 999)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, CompleteRideError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn complete_ride_returns_validation_error_on_422_when_the_ride_is_not_in_progress() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/complete"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Solo se puede completar un viaje que este en curso.",
+                "errors": {
+                    "ride": ["Solo se puede completar un viaje que este en curso."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.complete_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(
+            error,
+            CompleteRideError::Validation(ApiErrorBody {
+                message: "Solo se puede completar un viaje que este en curso.".to_string(),
+                errors: Some(HashMap::from([(
+                    "ride".to_string(),
+                    vec!["Solo se puede completar un viaje que este en curso.".to_string()]
+                )])),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_ride_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/complete"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/complete"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": sample_completed_ride_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.complete_ride(&sample_token(), 1).await.unwrap();
+
+        assert_eq!(fetch.data.id, 1);
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn complete_ride_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/complete"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.complete_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(error, CompleteRideError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn complete_ride_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client.complete_ride(&sample_token(), 1).await.unwrap_err();
+
+        assert!(matches!(error, CompleteRideError::Network(_)));
     }
 
     fn sample_location() -> Coordinates {

--- a/crates/moto_ui/src/screens/nearby_rides.rs
+++ b/crates/moto_ui/src/screens/nearby_rides.rs
@@ -62,6 +62,18 @@
 //! (de red, del backend, o del propio proveedor) se trata como transitorio y
 //! se reintenta en el siguiente ciclo, sin dejar el panel en un estado de
 //! error permanente.
+//!
+//! Tambien mientras el viaje esta `in_progress`, se ofrece "Completar
+//! viaje", que llama a `POST /api/v1/rides/{ride}/complete`
+//! (`ApiClient::complete_ride`, issue #23) — la condicion de estado hace
+//! que el boton no este disponible si el viaje no esta en curso (criterio
+//! de aceptacion del issue). El backend dispara el cobro (historia #25 del
+//! backend) en la misma operacion, asi que la respuesta ya trae
+//! `completed_at`, `final_fare` y `payment` resueltos; la pantalla
+//! reemplaza el viaje en pantalla por esa version y muestra un resumen
+//! (tarifa final y estado del pago) en vez de navegar a una pantalla de
+//! pago propia — la historia "Pagar el viaje al finalizar" (#24) sigue
+//! bloqueada del lado del backend, no hay adonde navegar todavia.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -69,8 +81,8 @@ use std::time::Duration;
 use dioxus::prelude::*;
 use futures_timer::Delay;
 use moto_core::api::{
-    AcceptRideError, ApiClient, AuthenticatedRequestError, CancelRideError, GetVehicleError,
-    ShareRideLocationError, StartRideError,
+    AcceptRideError, ApiClient, AuthenticatedRequestError, CancelRideError, CompleteRideError,
+    GetVehicleError, ShareRideLocationError, StartRideError,
 };
 use moto_core::location::{LocationError, LocationProvider};
 use moto_core::models::{NearbyRideRequest, Ride, RideStatus, apply_nearby_ride_event};
@@ -355,6 +367,31 @@ fn NearbyRidesList(props: NearbyRidesListProps) -> Element {
                         }
                     } else if ride.status == RideStatus::InProgress {
                         ShareLocationPanel { ride_id: ride.id }
+                        CompleteRideButton {
+                            ride_id: ride.id,
+                            on_completed: move |completed: Ride| {
+                                accepted_ride.set(Some(completed));
+                            },
+                        }
+                    } else if ride.status == RideStatus::Completed {
+                        div { class: "nearby-ride-completed",
+                            p { "Viaje completado." }
+                            if let Some(final_fare) = ride.final_fare {
+                                p { "Tarifa final: {ride.currency} {final_fare}" }
+                            }
+                            if let Some(payment) = &ride.payment {
+                                p {
+                                    "Pago: "
+                                    {
+                                        match payment.status {
+                                            moto_core::models::PaymentStatus::Paid => "pagado",
+                                            moto_core::models::PaymentStatus::Pending => "pendiente",
+                                            moto_core::models::PaymentStatus::Failed => "fallido",
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             } else {
@@ -544,6 +581,80 @@ fn StartRideButton(props: StartRideButtonProps) -> Element {
             }
             if let Some(message) = error() {
                 p { class: "nearby-ride-start-error", role: "alert", "{message}" }
+            }
+        }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct CompleteRideButtonProps {
+    ride_id: u64,
+    on_completed: EventHandler<Ride>,
+}
+
+/// Boton "Completar viaje" del viaje en curso (issue #23). Componente
+/// aparte, igual que `StartRideButton`, para que su estado de carga/error no
+/// dependa del resto de la pantalla. Al tener exito, la pantalla reemplaza
+/// el viaje en pantalla por la version devuelta por el backend (ahora
+/// `completed`, con `completed_at`, `final_fare` y `payment` ya resueltos —
+/// el cobro se dispara en la misma operacion, ver comentario de modulo).
+#[component]
+fn CompleteRideButton(props: CompleteRideButtonProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut is_completing = use_signal(|| false);
+    let mut error = use_signal(|| None::<String>);
+
+    let ride_id = props.ride_id;
+    let on_completed = props.on_completed;
+
+    let on_complete_click = move |_| {
+        let Some(token) = session.token() else {
+            return;
+        };
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_completing.set(true);
+            error.set(None);
+
+            match api_client.complete_ride(&token, ride_id).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    on_completed.call(fetch.data);
+                }
+                Err(CompleteRideError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    error.set(Some(err.to_string()));
+                }
+            }
+
+            is_completing.set(false);
+        });
+    };
+
+    rsx! {
+        div { class: "nearby-ride-complete",
+            button {
+                r#type: "button",
+                class: "nearby-ride-complete-button",
+                disabled: is_completing(),
+                onclick: on_complete_click,
+                if is_completing() {
+                    "Completando..."
+                } else {
+                    "Completar viaje"
+                }
+            }
+            if let Some(message) = error() {
+                p { class: "nearby-ride-complete-error", role: "alert", "{message}" }
             }
         }
     }


### PR DESCRIPTION
Closes #23

## Qué hace

Agrega el boton "Completar viaje" en `NearbyRidesScreen` para que el conductor pueda cerrar un viaje que tiene `in_progress`, llamando a `POST /api/v1/rides/{ride}/complete`.

- `ApiClient::complete_ride` en `crates/moto_core/src/api.rs`: mismo patron que `start_ride` (issue #18) — sin body, reintenta una vez con refresh de token ante un 401, y distingue `403` (Forbidden, viaje ajeno), `404` (NotFound) y `422` (Validation, el viaje no esta `in_progress`) sin reintentar en ninguno de esos casos. Devuelve el `Ride` ya `completed`, con `completed_at`, `final_fare` y `payment` resueltos por el backend en la misma operacion (el cobro se dispara al completar, segun `openapi.yaml`).
- `CompleteRideButton` en `crates/moto_ui/src/screens/nearby_rides.rs`: componente aparte (mismo patron que `StartRideButton`) para no afectar al resto de la pantalla mientras la llamada esta en curso. Solo se ofrece mientras `ride.status == RideStatus::InProgress` (criterio de aceptacion #2). Al tener exito, reemplaza el viaje en pantalla por la version devuelta por el backend, igual que hace `start_ride`.
- Nueva rama `ride.status == RideStatus::Completed` en `NearbyRidesList` que muestra un resumen (tarifa final y estado del pago) usando los campos que ya trae el `Ride` (`final_fare`, `payment.status`) — no se implemento navegacion a una pantalla de pago propia porque la historia "Pagar el viaje al finalizar" (#24) sigue bloqueada por un gap de contrato con el backend (ver el comentario que dejo en ese issue); esta rama es el lugar natural para conectar esa pantalla cuando se desbloquee.

No hubo cambios en `crates/moto_core/src/models.rs`: `Ride` ya tenia `final_fare`/`payment` y `RideStatus::Completed`, y ya habia un test de deserializacion cubriendo ese caso.

## Cómo se probó

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude mobile` (177 tests en verde, 7 nuevos en `moto_core::api::tests` para `complete_ride`: exito con `final_fare`/`payment`, 403, 404, 422, refresh-y-reintento en 401, sesion expirada, y error de red — mismo criterio de cobertura que `start_ride`)
- `cargo build --package web --target wasm32-unknown-unknown` (mismo build que corre en CI)
- Verificacion manual del contrato contra `openapi.yaml` del backend (`Back_App_MotoCarros`): confirme el path `/rides/{id}/complete`, los codigos 403/404/422, y que la respuesta 200 ya trae `payment`/`final_fare` resueltos — no hubo gap de contrato.

## Decisiones y riesgos

- No se implemento navegacion a una pantalla de pago (criterio de aceptacion #3 del issue, "navega al flujo de pago") porque esa pantalla no existe todavia — la historia #24 esta bloqueada por un gap real de contrato con el backend (no hay endpoint de pago invocable por el pasajero, ver el comentario dejado alli). En su lugar, la pantalla muestra el resultado del cobro (que ya llega resuelto en la respuesta de `complete`) directamente, satisfaciendo la intencion del criterio sin inventar una pantalla que todavia no corresponde construir.
- No se toco `models.rs`: el modelo `Ride`/`Payment` ya estaba completo para este caso.