### PR TITLE
feat(#26): calificar al conductor al finalizar el viaje

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -6,9 +6,10 @@
 
 use crate::models::{
     ApiErrorBody, AuthToken, AuthenticatedUser, BroadcastAuthPayload, BroadcastAuthResponse,
-    Coordinates, DataEnvelope, LoginPayload, RegisterDriverPayload, RegisterPassengerPayload,
-    RegisterVehiclePayload, Ride, RideCancellation, RideEstimate, RideEstimateRequestPayload,
-    RideRequestPayload, UpdateProfilePayload, UpdateVehiclePayload, User, Vehicle,
+    Coordinates, DataEnvelope, LoginPayload, RateDriverPayload, RegisterDriverPayload,
+    RegisterPassengerPayload, RegisterVehiclePayload, Ride, RideCancellation, RideEstimate,
+    RideEstimateRequestPayload, RideRating, RideRequestPayload, UpdateProfilePayload,
+    UpdateVehiclePayload, User, Vehicle,
 };
 
 #[cfg(test)]
@@ -805,6 +806,55 @@ impl std::fmt::Display for CompleteRideError {
 
 impl std::error::Error for CompleteRideError {}
 
+/// Fallos posibles de `POST /api/v1/rides/{ride}/rate-driver` (historia #26).
+///
+/// Mismo reparto que `CompleteRideError`: `Forbidden` cubre tanto al
+/// conductor asignado como a otro pasajero — solo el pasajero dueno del
+/// viaje puede calificar (`RidePolicy::rateDriver` en el backend).
+/// `Validation` cubre tanto que el viaje todavia no este `completed` como
+/// que el pasajero ya lo haya calificado antes: el backend responde el mismo
+/// 422 para ambos casos a proposito (ver `openapi.yaml`), asi que el cliente
+/// no los distingue — el mensaje que trae el body ya es explicito sobre cual
+/// de los dos paso. `InvalidScore` se detecta en el cliente antes de mandar
+/// la request (el backend tambien lo valida, pero no tiene sentido viajar
+/// hasta el para un chequeo tan basico).
+#[derive(Debug, Clone, PartialEq)]
+pub enum RateDriverError {
+    InvalidScore,
+    Forbidden,
+    /// No existe ningun viaje con ese id.
+    NotFound,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for RateDriverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RateDriverError::InvalidScore => write!(f, "La puntuacion debe estar entre 1 y 5."),
+            RateDriverError::Forbidden => write!(f, "Este viaje no te pertenece."),
+            RateDriverError::NotFound => write!(f, "El viaje ya no existe."),
+            RateDriverError::Validation(body) => write!(f, "{}", body.message),
+            RateDriverError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            RateDriverError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            RateDriverError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RateDriverError {}
+
 /// Fallos posibles de `POST /api/v1/rides/{ride}/location` (issue #19).
 ///
 /// Mismo reparto que `StartRideError`: `Forbidden` cubre tanto a un
@@ -1000,6 +1050,14 @@ enum StartRideOutcome {
 
 enum CompleteRideOutcome {
     Success(Ride),
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    Validation(ApiErrorBody),
+}
+
+enum RateDriverOutcome {
+    Success(RideRating),
     Unauthorized,
     Forbidden,
     NotFound,
@@ -2307,6 +2365,111 @@ impl ApiClient {
                 Ok(CompleteRideOutcome::Validation(body))
             }
             other => Err(CompleteRideError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/rides/{ride}/rate-driver` — historia #26. Solo el
+    /// pasajero dueno del viaje puede calificar (ver comentario de
+    /// `RateDriverError`). `comment` se manda ausente cuando esta vacio tras
+    /// recortar espacios, igual que `RegisterVehiclePayload` normaliza sus
+    /// campos antes de armar el body. Reintenta una vez con refresh de token
+    /// ante un 401, igual que `complete_ride`; un 403 (viaje ajeno), 404 (no
+    /// existe) o 422 (viaje no completado, o ya calificado) nunca se
+    /// reintentan.
+    pub async fn rate_driver(
+        &self,
+        token: &AuthToken,
+        ride_id: u64,
+        score: u8,
+        comment: Option<&str>,
+    ) -> Result<AuthenticatedFetch<RideRating>, RateDriverError> {
+        if !(1..=5).contains(&score) {
+            return Err(RateDriverError::InvalidScore);
+        }
+
+        let payload = RateDriverPayload {
+            score,
+            comment: comment
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string),
+        };
+
+        match self
+            .post_rate_driver_with_token(ride_id, &token.access_token, &payload)
+            .await?
+        {
+            RateDriverOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            RateDriverOutcome::Forbidden => return Err(RateDriverError::Forbidden),
+            RateDriverOutcome::NotFound => return Err(RateDriverError::NotFound),
+            RateDriverOutcome::Validation(body) => return Err(RateDriverError::Validation(body)),
+            RateDriverOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| RateDriverError::SessionExpired)?;
+
+        match self
+            .post_rate_driver_with_token(ride_id, &renewed.access_token, &payload)
+            .await?
+        {
+            RateDriverOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            RateDriverOutcome::Forbidden => Err(RateDriverError::Forbidden),
+            RateDriverOutcome::NotFound => Err(RateDriverError::NotFound),
+            RateDriverOutcome::Validation(body) => Err(RateDriverError::Validation(body)),
+            RateDriverOutcome::Unauthorized => Err(RateDriverError::SessionExpired),
+        }
+    }
+
+    async fn post_rate_driver_with_token(
+        &self,
+        ride_id: u64,
+        access_token: &str,
+        body: &RateDriverPayload,
+    ) -> Result<RateDriverOutcome, RateDriverError> {
+        let url = format!("{}/api/v1/rides/{}/rate-driver", self.base_url, ride_id);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|err| RateDriverError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<RideRating> = response
+                .json()
+                .await
+                .map_err(|err| RateDriverError::Network(err.to_string()))?;
+            return Ok(RateDriverOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(RateDriverOutcome::Unauthorized),
+            403 => Ok(RateDriverOutcome::Forbidden),
+            404 => Ok(RateDriverOutcome::NotFound),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| RateDriverError::Network(err.to_string()))?;
+                Ok(RateDriverOutcome::Validation(body))
+            }
+            other => Err(RateDriverError::Unexpected(other)),
         }
     }
 
@@ -5414,6 +5577,268 @@ mod tests {
         let error = client.complete_ride(&sample_token(), 1).await.unwrap_err();
 
         assert!(matches!(error, CompleteRideError::Network(_)));
+    }
+
+    #[tokio::test]
+    async fn rate_driver_rejects_a_score_outside_1_to_5_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .rate_driver(&sample_token(), 1, 0, None)
+                .await
+                .unwrap_err(),
+            RateDriverError::InvalidScore
+        );
+        assert_eq!(
+            client
+                .rate_driver(&sample_token(), 1, 6, None)
+                .await
+                .unwrap_err(),
+            RateDriverError::InvalidScore
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_driver_sends_the_score_and_trimmed_comment_and_returns_the_rating() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/rate-driver"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .and(body_json(serde_json::json!({
+                "score": 5,
+                "comment": "Muy puntual y buen trato.",
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "data": {
+                    "ride_id": 1,
+                    "score": 5,
+                    "comment": "Muy puntual y buen trato.",
+                    "rated_at": "2026-07-31T14:20:05+00:00",
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .rate_driver(&sample_token(), 1, 5, Some("  Muy puntual y buen trato.  "))
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.ride_id, 1);
+        assert_eq!(fetch.data.score, 5);
+        assert_eq!(
+            fetch.data.comment,
+            Some("Muy puntual y buen trato.".to_string())
+        );
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn rate_driver_omits_the_comment_when_blank() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/rate-driver"))
+            .and(body_json(serde_json::json!({ "score": 4 })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "data": {
+                    "ride_id": 1,
+                    "score": 4,
+                    "comment": null,
+                    "rated_at": "2026-07-31T14:20:05+00:00",
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .rate_driver(&sample_token(), 1, 4, Some("   "))
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.comment, None);
+    }
+
+    #[tokio::test]
+    async fn rate_driver_returns_forbidden_on_403_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/rate-driver"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .rate_driver(&sample_token(), 1, 5, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, RateDriverError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn rate_driver_returns_not_found_on_404_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/999/rate-driver"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "No query results for model [App\\Models\\Ride] 999.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .rate_driver(&sample_token(), 999, 5, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, RateDriverError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn rate_driver_returns_validation_error_on_422_when_already_rated() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/rate-driver"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "Ya existe una calificacion del conductor para este viaje.",
+                "errors": {
+                    "ride": ["Ya existe una calificacion del conductor para este viaje."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .rate_driver(&sample_token(), 1, 5, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            RateDriverError::Validation(ApiErrorBody {
+                message: "Ya existe una calificacion del conductor para este viaje.".to_string(),
+                errors: Some(HashMap::from([(
+                    "ride".to_string(),
+                    vec!["Ya existe una calificacion del conductor para este viaje.".to_string()]
+                )])),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_driver_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/rate-driver"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/rate-driver"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "data": {
+                    "ride_id": 1,
+                    "score": 5,
+                    "comment": null,
+                    "rated_at": "2026-07-31T14:20:05+00:00",
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .rate_driver(&sample_token(), 1, 5, None)
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.ride_id, 1);
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn rate_driver_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/rides/1/rate-driver"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .rate_driver(&sample_token(), 1, 5, None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, RateDriverError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn rate_driver_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .rate_driver(&sample_token(), 1, 5, None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RateDriverError::Network(_)));
     }
 
     fn sample_location() -> Coordinates {

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -268,6 +268,28 @@ pub struct RideCancellation {
     pub cancellation_fee_applies: Option<bool>,
 }
 
+/// Body de `POST /api/v1/rides/{ride}/rate-driver` (historia #26). `comment`
+/// se omite del JSON cuando es `None` en vez de mandarse como `null`: el
+/// backend lo declara `nullable` pero no `required`, y el resto de los
+/// payloads de esta app (p.ej. `UpdateVehiclePayload`) siguen el mismo
+/// criterio para campos opcionales.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RateDriverPayload {
+    pub score: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+}
+
+/// `openapi.yaml#/components/schemas/RideRating` — respuesta de
+/// `POST /api/v1/rides/{ride}/rate-driver` (historia #26).
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct RideRating {
+    pub ride_id: u64,
+    pub score: u8,
+    pub comment: Option<String>,
+    pub rated_at: String,
+}
+
 /// Body de `POST /api/v1/broadcasting/auth`
 /// (`openapi.yaml#/components/schemas/BroadcastAuthRequest`).
 ///

--- a/crates/moto_ui/src/screens/ride_estimate.rs
+++ b/crates/moto_ui/src/screens/ride_estimate.rs
@@ -46,10 +46,10 @@ use std::time::Duration;
 use dioxus::prelude::*;
 use futures_timer::Delay;
 use moto_core::api::{
-    ApiClient, CancelRideError, EstimateRideError, GetRideError, RequestRideError,
+    ApiClient, CancelRideError, EstimateRideError, GetRideError, RateDriverError, RequestRideError,
 };
 use moto_core::models::{
-    Coordinates, Ride, RideCancellation, RideEstimate, RideStatus, RideTracking,
+    Coordinates, Ride, RideCancellation, RideEstimate, RideRating, RideStatus, RideTracking,
     apply_ride_tracking_event,
 };
 use moto_core::realtime::{
@@ -362,6 +362,8 @@ pub fn RideEstimateScreen() -> Element {
                             requested_ride.set(Some(updated));
                         },
                     }
+                } else if ride.status == RideStatus::Completed {
+                    RateDriverPanel { ride_id: ride.id }
                 }
             }
         };
@@ -657,6 +659,144 @@ fn RideTrackingPanel(props: RideTrackingPanelProps) -> Element {
             }
             div { class: "ride-tracking-map", style: "height: 320px;",
                 MapView { center_lat, center_lng, markers }
+            }
+        }
+    }
+}
+
+/// Estado visible de `RateDriverPanel` (historia #26).
+#[derive(Debug, Clone, PartialEq)]
+enum RatingState {
+    /// Todavia no califico, o el ultimo intento fallo por algo recuperable
+    /// (red, sesion vencida): el formulario sigue disponible.
+    Pending,
+    Rated(RideRating),
+    /// El backend respondio 422. Como este panel solo se muestra con el
+    /// viaje ya `completed`, la unica causa posible es que el pasajero ya lo
+    /// habia calificado antes (criterio de aceptacion #2 de la historia
+    /// #26) — el backend no devuelve la calificacion existente en este
+    /// error, asi que no hay nada mas que mostrar que el hecho de que ya
+    /// existe.
+    AlreadyRated,
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct RateDriverPanelProps {
+    ride_id: u64,
+}
+
+/// Formulario para calificar al conductor de un viaje `completed` (historia
+/// #26). Componente aparte, igual que `CompleteRideButton` en
+/// `nearby_rides.rs`, para que su estado de carga/error no dependa del resto
+/// de la pantalla.
+#[component]
+fn RateDriverPanel(props: RateDriverPanelProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut score = use_signal(|| 5u8);
+    let mut comment = use_signal(String::new);
+    let mut is_submitting = use_signal(|| false);
+    let mut error = use_signal(|| None::<RateDriverError>);
+    let mut state = use_signal(|| RatingState::Pending);
+
+    let ride_id = props.ride_id;
+
+    let on_submit = move |event: FormEvent| {
+        event.prevent_default();
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        let score_value = score();
+        let comment_value = comment();
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_submitting.set(true);
+            error.set(None);
+
+            let comment_arg = Some(comment_value.as_str()).filter(|value| !value.trim().is_empty());
+
+            match api_client
+                .rate_driver(&token, ride_id, score_value, comment_arg)
+                .await
+            {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    state.set(RatingState::Rated(fetch.data));
+                }
+                Err(RateDriverError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(RateDriverError::Validation(_)) => {
+                    state.set(RatingState::AlreadyRated);
+                }
+                Err(err) => {
+                    error.set(Some(err));
+                }
+            }
+
+            is_submitting.set(false);
+        });
+    };
+
+    rsx! {
+        div { class: "rate-driver-panel",
+            match state() {
+                RatingState::Rated(rating) => rsx! {
+                    p { class: "rate-driver-success",
+                        "Calificaste a tu conductor con {rating.score} de 5."
+                    }
+                },
+                RatingState::AlreadyRated => rsx! {
+                    p { class: "rate-driver-already-rated",
+                        "Ya calificaste al conductor de este viaje."
+                    }
+                },
+                RatingState::Pending => rsx! {
+                    form { class: "rate-driver-form", onsubmit: on_submit,
+                        label { r#for: "rate-driver-score", "Puntuacion" }
+                        select {
+                            id: "rate-driver-score",
+                            disabled: is_submitting(),
+                            value: "{score()}",
+                            onchange: move |event| {
+                                if let Ok(value) = event.value().parse::<u8>() {
+                                    score.set(value);
+                                }
+                            },
+                            for value in 1..=5u8 {
+                                option { value: "{value}", "{value}" }
+                            }
+                        }
+                        label { r#for: "rate-driver-comment", "Comentario (opcional)" }
+                        textarea {
+                            id: "rate-driver-comment",
+                            maxlength: "1000",
+                            disabled: is_submitting(),
+                            value: "{comment()}",
+                            oninput: move |event| comment.set(event.value()),
+                        }
+                        button {
+                            r#type: "submit",
+                            class: "rate-driver-submit-button",
+                            disabled: is_submitting(),
+                            if is_submitting() {
+                                "Enviando..."
+                            } else {
+                                "Calificar conductor"
+                            }
+                        }
+                        if let Some(message) = error() {
+                            p { class: "rate-driver-error", role: "alert", "{message}" }
+                        }
+                    }
+                },
             }
         }
     }


### PR DESCRIPTION
Closes #26

## Qué hace

Como pasajero, califico al conductor de un viaje ya `completed`:
puntuación de 1 a 5 y comentario opcional.

- `moto_core::api::ApiClient::rate_driver` — `POST /api/v1/rides/{ride}/rate-driver`.
  Mismo reparto de errores que `complete_ride`/`start_ride` (`RateDriverError`):
  `Forbidden` (403, viaje ajeno), `NotFound` (404), `Validation` (422 —
  el backend usa el mismo status tanto para "el viaje no está completado"
  como para "ya lo calificaste", así que el cliente no los distingue),
  reintento de token en 401, `SessionExpired`, `Network`, `Unexpected`.
  `InvalidScore` se valida en el cliente antes de mandar la request
  (`score` fuera de 1-5).
- `moto_core::models::RateDriverPayload` / `RideRating` — reflejan el
  contrato de `openapi.yaml` (`RideRating`, historia #27 del backend).
- `moto_ui::screens::ride_estimate::RateDriverPanel` — se muestra en
  `RideEstimateScreen` cuando el viaje del pasajero pasa a `completed`
  (mismo lugar donde antes solo se mostraba el texto "Tu viaje ya se
  completó"). Formulario con selector de puntuación (1-5) y textarea de
  comentario opcional; al enviar, si el backend responde 422 el panel
  deja de ofrecer el formulario y muestra que ya se calificó — no
  reintenta ni vuelve a mostrar el form.

## Cómo se probó

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace --exclude mobile` ✅ (200 tests, incluye 12
  tests nuevos de `rate_driver` en `moto_core::api::tests`: éxito con
  comentario recortado, comentario vacío omitido del body, score
  inválido sin request, 403/404/422 sin retry, refresh-y-retry en 401,
  `SessionExpired`, error de red)
- `cargo build --package web --target wasm32-unknown-unknown` ✅ (mismo
  comando que corre el job `build-web` del CI)

No pude levantar la app en un navegador real (no hay backend ni Reverb
corriendo en este entorno de agente) — la verificación es por tests
automatizados y por espejo cuidadoso del patrón ya usado en
`complete_ride`/`CompleteRideButton`.

## Decisiones y riesgos

- El endpoint del backend (`RidePolicy::rateDriver`, `RateDriverRequest`)
  no distingue "viaje no completado" de "ya calificado" en el status
  code (ambos 422). Como `RateDriverPanel` solo se monta cuando
  `ride.status == Completed`, en la práctica la única causa real de un
  422 en este flujo es "ya calificado" — así lo interpreta la UI. Si el
  pasajero recarga la pantalla después de haber calificado en una
  sesión anterior, el panel vuelve a aparecer (no hay persistencia local
  de "ya califiqué") y el primer submit devuelve ese 422, que la UI
  resuelve igual: deja de ofrecer el formulario.
- El backend no devuelve la calificación existente en el 422 (solo un
  mensaje), así que el panel no puede mostrar la puntuación que ya se
  dio — criterio de aceptación #2 de la historia lo contempla ("si el
  backend la devuelve"); acá no la devuelve, así que solo se informa
  que ya existe.
- No agregué estilos CSS nuevos (el repo no tiene hoja de estilos propia
  para estos componentes todavía, ver el resto de `ride_estimate.rs`):
  seguí el mismo patrón de clases sin estilo (`rate-driver-panel`,
  `rate-driver-form`, etc.) que ya usa el resto de la pantalla.