### PR TITLE
feat(#28): ver historial de viajes (pasajero)

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -13,7 +13,7 @@ use crate::models::{
 };
 
 #[cfg(test)]
-use crate::models::Role;
+use crate::models::{RideStatus, Role};
 
 #[derive(Debug, Clone)]
 pub struct ApiClient {
@@ -1429,6 +1429,21 @@ impl ApiClient {
         token: &AuthToken,
     ) -> Result<AuthenticatedFetch<User>, AuthenticatedRequestError> {
         self.get_authenticated::<User>("/api/v1/me", token).await
+    }
+
+    /// `GET /api/v1/me/rides` — historia #28. El mismo endpoint devuelve los
+    /// viajes que el pasajero pidio, o los que le asignaron si la cuenta es
+    /// de conductor (historia #29, fuera de alcance aca) — lo decide
+    /// `ShowRideHistoryController` en el backend segun el rol de la cuenta.
+    /// No manda `page` ni `per_page`: esta historia solo pide la primera
+    /// pagina (ver `openapi.yaml`), paginar mas alla del default del backend
+    /// queda para una historia aparte.
+    pub async fn ride_history(
+        &self,
+        token: &AuthToken,
+    ) -> Result<AuthenticatedFetch<Vec<Ride>>, AuthenticatedRequestError> {
+        self.get_authenticated::<Vec<Ride>>("/api/v1/me/rides", token)
+            .await
     }
 
     /// `PATCH /api/v1/me` — issue #10. PATCH parcial: solo los campos
@@ -3509,6 +3524,112 @@ mod tests {
 
         let client = ApiClient::new(server.uri());
         let error = client.me(&sample_token()).await.unwrap_err();
+
+        assert_eq!(error, AuthenticatedRequestError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn ride_history_returns_the_rides_ordered_by_the_backend() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/rides"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [
+                    {
+                        "id": 2,
+                        "status": "completed",
+                        "origin": { "latitude": 4.710989, "longitude": -74.072092 },
+                        "destination": { "latitude": 4.698, "longitude": -74.061 },
+                        "distance_meters": 7421,
+                        "duration_seconds": 842,
+                        "currency": "COP",
+                        "estimated_fare": 8850,
+                        "driver": { "id": 5, "name": "Carlos Perez" },
+                        "requested_at": "2026-07-31T14:03:21+00:00",
+                        "started_at": "2026-07-31T14:05:00+00:00",
+                        "completed_at": "2026-07-31T14:22:00+00:00",
+                        "final_fare": 9100,
+                        "payment": { "status": "paid" }
+                    },
+                    {
+                        "id": 1,
+                        "status": "cancelled",
+                        "origin": { "latitude": 4.71, "longitude": -74.07 },
+                        "destination": { "latitude": 4.69, "longitude": -74.06 },
+                        "distance_meters": 5000,
+                        "duration_seconds": 600,
+                        "currency": "COP",
+                        "estimated_fare": 6000,
+                        "driver": null,
+                        "requested_at": "2026-07-30T10:00:00+00:00",
+                        "started_at": null,
+                        "completed_at": null,
+                        "final_fare": null,
+                        "payment": null
+                    }
+                ],
+                "meta": { "current_page": 1, "per_page": 15, "total": 2, "last_page": 1 }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.ride_history(&sample_token()).await.unwrap();
+
+        assert_eq!(fetch.data.len(), 2);
+        assert_eq!(fetch.data[0].id, 2);
+        assert_eq!(fetch.data[0].status, RideStatus::Completed);
+        assert_eq!(fetch.data[1].id, 1);
+        assert_eq!(fetch.data[1].driver, None);
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn ride_history_returns_an_empty_list_when_the_account_has_no_rides() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/rides"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [],
+                "meta": { "current_page": 1, "per_page": 15, "total": 0, "last_page": 1 }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.ride_history(&sample_token()).await.unwrap();
+
+        assert!(fetch.data.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ride_history_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/rides"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.ride_history(&sample_token()).await.unwrap_err();
 
         assert_eq!(error, AuthenticatedRequestError::SessionExpired);
     }

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -17,6 +17,7 @@ pub use screens::register_driver::RegisterDriverScreen;
 pub use screens::register_passenger::RegisterPassengerScreen;
 pub use screens::register_vehicle::RegisterVehicleScreen;
 pub use screens::ride_estimate::RideEstimateScreen;
+pub use screens::ride_history::RideHistoryScreen;
 pub use screens::vehicle::VehicleScreen;
 
 /// Pantallas del flujo de autenticacion, previas a tener sesion iniciada.
@@ -84,6 +85,7 @@ enum HomeSection {
     RideEstimate,
     Vehicle,
     NearbyRides,
+    RideHistory,
 }
 
 /// Pantalla principal tras iniciar sesion: perfil (issue #9), tarifa
@@ -96,6 +98,9 @@ enum HomeSection {
 /// cuando `session.user()` ya cargo (`GET /api/v1/me`, issue #9) y es una
 /// cuenta de conductor: un pasajero nunca ve esos botones, y
 /// estructuralmente no puede llegar a esas pantallas desde esta navegacion.
+/// El historial de viajes (issue #28, `RideHistoryScreen`) es al reves:
+/// solo se ofrece a pasajero — el equivalente para conductor es la historia
+/// #29, todavia sin implementar.
 #[component]
 fn Home() -> Element {
     let api_client = use_context::<ApiClient>();
@@ -157,6 +162,13 @@ fn Home() -> Element {
                         onclick: move |_| section.set(HomeSection::NearbyRides),
                         "Solicitudes cercanas"
                     }
+                } else {
+                    button {
+                        r#type: "button",
+                        disabled: section() == HomeSection::RideHistory,
+                        onclick: move |_| section.set(HomeSection::RideHistory),
+                        "Historial de viajes"
+                    }
                 }
             }
             match section() {
@@ -171,6 +183,9 @@ fn Home() -> Element {
                 },
                 HomeSection::NearbyRides => rsx! {
                     NearbyRidesScreen {}
+                },
+                HomeSection::RideHistory => rsx! {
+                    RideHistoryScreen {}
                 },
             }
             button {

--- a/crates/moto_ui/src/screens/mod.rs
+++ b/crates/moto_ui/src/screens/mod.rs
@@ -5,4 +5,5 @@ pub mod register_driver;
 pub mod register_passenger;
 pub mod register_vehicle;
 pub mod ride_estimate;
+pub mod ride_history;
 pub mod vehicle;

--- a/crates/moto_ui/src/screens/ride_history.rs
+++ b/crates/moto_ui/src/screens/ride_history.rs
@@ -1,0 +1,149 @@
+//! Pantalla de historial de viajes (pasajero) — issue #28.
+//!
+//! Al entrar, consulta `GET /api/v1/me/rides` (`ApiClient::ride_history`) y
+//! muestra los viajes que pidio la cuenta, del mas reciente al mas antiguo
+//! (el orden ya lo decide el backend, `ShowRideHistoryController`). Una
+//! cuenta sin viajes previos recibe una lista vacia, no un error, asi que
+//! ese caso se distingue con un estado vacio explicito en vez de mostrar la
+//! lista en blanco (criterio de aceptacion del issue).
+//!
+//! El equivalente para conductor (historial + resumen de ganancias) es la
+//! historia #29, fuera de alcance aca — `Home` (`moto_ui/src/lib.rs`) solo
+//! ofrece esta pestana a cuentas de pasajero.
+
+use std::sync::Arc;
+
+use dioxus::prelude::*;
+use moto_core::api::{ApiClient, AuthenticatedRequestError};
+use moto_core::models::{Ride, RideStatus};
+use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
+
+#[component]
+pub fn RideHistoryScreen() -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut is_loading = use_signal(|| false);
+    let mut load_error = use_signal(|| None::<String>);
+    let mut rides = use_signal(Vec::<Ride>::new);
+    // Misma guarda que `VehicleScreen`/`ProfileScreen`: el efecto lee
+    // `session.token()` en su primera corrida, lo que lo suscribe a ese
+    // signal, y el fetch puede terminar escribiendo en `session` (refresh de
+    // token, logout) — sin esta bandera reprogramaria el efecto en un loop.
+    let mut has_fetched = use_signal(|| false);
+
+    use_effect(move || {
+        if has_fetched() {
+            return;
+        }
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        has_fetched.set(true);
+
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            load_error.set(None);
+
+            match api_client.ride_history(&token).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    rides.set(fetch.data);
+                }
+                Err(AuthenticatedRequestError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    load_error.set(Some(err.to_string()));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    });
+
+    rsx! {
+        div { class: "ride-history-screen",
+            h2 { "Historial de viajes" }
+            if is_loading() {
+                p { "Cargando..." }
+            } else if let Some(message) = load_error() {
+                p { class: "ride-history-error", role: "alert", "{message}" }
+            } else if rides().is_empty() {
+                p { class: "ride-history-empty", "Todavia no tienes viajes." }
+            } else {
+                ul { class: "ride-history-list",
+                    for ride in rides() {
+                        RideHistoryRow { key: "{ride.id}", ride }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct RideHistoryRowProps {
+    ride: Ride,
+}
+
+#[component]
+fn RideHistoryRow(props: RideHistoryRowProps) -> Element {
+    let ride = &props.ride;
+    let fare = ride.final_fare.unwrap_or(ride.estimated_fare);
+
+    rsx! {
+        li { class: "ride-history-row",
+            p { class: "ride-history-status", "{ride_status_label(ride.status)}" }
+            p { "Fecha: {ride.requested_at}" }
+            p { "Origen: {ride.origin.latitude}, {ride.origin.longitude}" }
+            p { "Destino: {ride.destination.latitude}, {ride.destination.longitude}" }
+            p { "Tarifa: {ride.currency} {fare}" }
+            if let Some(driver) = &ride.driver {
+                p { "Conductor: {driver.name}" }
+            }
+        }
+    }
+}
+
+/// Texto del estado de un viaje del historial, tal como lo ve el pasajero.
+fn ride_status_label(status: RideStatus) -> &'static str {
+    match status {
+        RideStatus::Requested => "Esperando conductor",
+        RideStatus::Accepted => "Conductor asignado",
+        RideStatus::InProgress => "En curso",
+        RideStatus::Completed => "Completado",
+        RideStatus::Cancelled => "Cancelado",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ride_status_label_describes_a_completed_ride() {
+        assert_eq!(ride_status_label(RideStatus::Completed), "Completado");
+    }
+
+    #[test]
+    fn ride_status_label_describes_a_cancelled_ride() {
+        assert_eq!(ride_status_label(RideStatus::Cancelled), "Cancelado");
+    }
+
+    #[test]
+    fn ride_status_label_describes_a_ride_still_waiting_for_a_driver() {
+        assert_eq!(
+            ride_status_label(RideStatus::Requested),
+            "Esperando conductor"
+        );
+    }
+}


### PR DESCRIPTION
Closes #28

## Que hace
Agrega la pantalla de historial de viajes del pasajero, consumiendo
`GET /api/v1/me/rides` del backend (`Back_App_MotoCarros`).

- `ApiClient::ride_history` (`crates/moto_core/src/api.rs`): nuevo wrapper
  sobre `get_authenticated::<Vec<Ride>>`, mismo patron que `ApiClient::me`.
  No manda `page`/`per_page`: esta historia solo pide la primera pagina
  (el backend ya ordena del viaje mas reciente al mas antiguo), paginar mas
  alla queda fuera de alcance.
- `RideHistoryScreen` (`crates/moto_ui/src/screens/ride_history.rs`): pantalla
  nueva, mismo patron de fetch-on-mount con guarda `has_fetched` que
  `VehicleScreen`/`ProfileScreen`. Muestra estado de carga, error, un estado
  vacio explicito ("Todavia no tienes viajes.") cuando la cuenta no tiene
  viajes, o la lista con fecha, origen/destino, estado, tarifa (final si el
  viaje ya se completo, estimada si no) y el conductor asignado si lo hay.
- `Home` (`crates/moto_ui/src/lib.rs`): nueva pestana "Historial de viajes",
  ofrecida solo a cuentas de pasajero (el equivalente de conductor es la
  historia #29, todavia sin implementar, y consume el mismo endpoint pero
  con otro contenido segun el criterio de aceptacion de la #28).

## Como se probo
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude mobile` (206 tests, incluye 3 tests
  nuevos de `ApiClient::ride_history` con HTTP mockeado — lista con viajes,
  lista vacia, y sesion expirada — y 3 tests unitarios del label de estado
  en la pantalla)
- `cargo build --package web --target wasm32-unknown-unknown`

## Decisiones y riesgos
- El endpoint es compartido entre pasajero y conductor
  (`ShowRideHistoryController` en el backend decide segun el rol), pero esta
  historia es exclusiva de pasajero: la pestana de `Home` solo se ofrece
  cuando la cuenta no es de conductor, siguiendo el mismo criterio de
  aceptacion del issue.
- No se implemento paginacion (controles de pagina siguiente/anterior): el
  issue esta estimado como S y sus criterios de aceptacion no la piden, solo
  pide listar y mostrar un estado vacio explicito. El backend sigue
  paginando internamente (`meta` en la respuesta), pero el cliente solo pide
  la primera pagina por ahora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)