### PR TITLE
feat(#29): ver historial de viajes y ganancias (conductor)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4517,6 +4517,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2024"
 dioxus = { version = "0.7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "webpki-roots"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "query", "rustls", "webpki-roots"] }

--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -6,10 +6,10 @@
 
 use crate::models::{
     ApiErrorBody, AuthToken, AuthenticatedUser, BroadcastAuthPayload, BroadcastAuthResponse,
-    Coordinates, DataEnvelope, LoginPayload, RateDriverPayload, RegisterDriverPayload,
-    RegisterPassengerPayload, RegisterVehiclePayload, Ride, RideCancellation, RideEstimate,
-    RideEstimateRequestPayload, RideRating, RideRequestPayload, UpdateProfilePayload,
-    UpdateVehiclePayload, User, Vehicle,
+    Coordinates, DataEnvelope, DriverEarningsSummary, LoginPayload, RateDriverPayload,
+    RegisterDriverPayload, RegisterPassengerPayload, RegisterVehiclePayload, Ride,
+    RideCancellation, RideEstimate, RideEstimateRequestPayload, RideRating, RideRequestPayload,
+    UpdateProfilePayload, UpdateVehiclePayload, User, Vehicle,
 };
 
 #[cfg(test)]
@@ -977,6 +977,48 @@ impl std::fmt::Display for BroadcastAuthError {
 
 impl std::error::Error for BroadcastAuthError {}
 
+/// Fallos posibles de `GET /api/v1/me/earnings` (historia #29).
+///
+/// `Validation` cubre tanto `from`/`to` ausentes o con formato invalido como
+/// `to` anterior a `from` (`ShowDriverEarningsRequest::rules()` en el
+/// backend): el backend responde el mismo 422 para los tres casos, asi que
+/// el cliente no los distingue — el mensaje que trae el body ya es explicito
+/// sobre cual de los tres paso.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GetDriverEarningsError {
+    /// La cuenta no es de conductor (`RidePolicy::viewEarnings` en el backend).
+    Forbidden,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for GetDriverEarningsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GetDriverEarningsError::Forbidden => {
+                write!(f, "Esta cuenta no puede consultar ganancias.")
+            }
+            GetDriverEarningsError::Validation(body) => write!(f, "{}", body.message),
+            GetDriverEarningsError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            GetDriverEarningsError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            GetDriverEarningsError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GetDriverEarningsError {}
+
 enum GetOutcome<T> {
     Success(T),
     Unauthorized,
@@ -1077,6 +1119,13 @@ enum GetRideOutcome<T> {
     Unauthorized,
     Forbidden,
     NotFound,
+}
+
+enum GetEarningsOutcome<T> {
+    Success(T),
+    Unauthorized,
+    Forbidden,
+    Validation(ApiErrorBody),
 }
 
 impl ApiClient {
@@ -1444,6 +1493,96 @@ impl ApiClient {
     ) -> Result<AuthenticatedFetch<Vec<Ride>>, AuthenticatedRequestError> {
         self.get_authenticated::<Vec<Ride>>("/api/v1/me/rides", token)
             .await
+    }
+
+    /// `GET /api/v1/me/earnings` — historia #29. `from`/`to` viajan tal cual
+    /// los eligio el usuario (formato `YYYY-MM-DD` de un `<input type="date">`,
+    /// ver `DriverEarningsScreen`): el backend es quien valida formato y
+    /// orden (`ShowDriverEarningsRequest`), asi que el cliente no duplica esa
+    /// regla. Reintenta una vez con refresh de token ante un 401, igual que
+    /// `get_vehicle`; un 403 (cuenta no conductora) o un 422 (validacion)
+    /// nunca se reintentan.
+    pub async fn driver_earnings(
+        &self,
+        token: &AuthToken,
+        from: &str,
+        to: &str,
+    ) -> Result<AuthenticatedFetch<DriverEarningsSummary>, GetDriverEarningsError> {
+        match self
+            .get_earnings_with_token(&token.access_token, from, to)
+            .await?
+        {
+            GetEarningsOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            GetEarningsOutcome::Forbidden => return Err(GetDriverEarningsError::Forbidden),
+            GetEarningsOutcome::Validation(body) => {
+                return Err(GetDriverEarningsError::Validation(body));
+            }
+            GetEarningsOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| GetDriverEarningsError::SessionExpired)?;
+
+        match self
+            .get_earnings_with_token(&renewed.access_token, from, to)
+            .await?
+        {
+            GetEarningsOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            GetEarningsOutcome::Forbidden => Err(GetDriverEarningsError::Forbidden),
+            GetEarningsOutcome::Validation(body) => Err(GetDriverEarningsError::Validation(body)),
+            GetEarningsOutcome::Unauthorized => Err(GetDriverEarningsError::SessionExpired),
+        }
+    }
+
+    async fn get_earnings_with_token(
+        &self,
+        access_token: &str,
+        from: &str,
+        to: &str,
+    ) -> Result<GetEarningsOutcome<DriverEarningsSummary>, GetDriverEarningsError> {
+        let url = format!("{}/api/v1/me/earnings", self.base_url);
+
+        let response = self
+            .http
+            .get(url)
+            .query(&[("from", from), ("to", to)])
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|err| GetDriverEarningsError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<DriverEarningsSummary> = response
+                .json()
+                .await
+                .map_err(|err| GetDriverEarningsError::Network(err.to_string()))?;
+            return Ok(GetEarningsOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(GetEarningsOutcome::Unauthorized),
+            403 => Ok(GetEarningsOutcome::Forbidden),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| GetDriverEarningsError::Network(err.to_string()))?;
+                Ok(GetEarningsOutcome::Validation(body))
+            }
+            other => Err(GetDriverEarningsError::Unexpected(other)),
+        }
     }
 
     /// `PATCH /api/v1/me` — issue #10. PATCH parcial: solo los campos
@@ -3632,6 +3771,213 @@ mod tests {
         let error = client.ride_history(&sample_token()).await.unwrap_err();
 
         assert_eq!(error, AuthenticatedRequestError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn driver_earnings_returns_the_summary_for_the_requested_range() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/earnings"))
+            .and(wiremock::matchers::query_param("from", "2026-07-01"))
+            .and(wiremock::matchers::query_param("to", "2026-07-31"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "from": "2026-07-01",
+                    "to": "2026-07-31",
+                    "currency": "COP",
+                    "total_earned": 17500,
+                    "completed_rides": 2,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .driver_earnings(&sample_token(), "2026-07-01", "2026-07-31")
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.total_earned, 17500);
+        assert_eq!(fetch.data.completed_rides, 2);
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn driver_earnings_returns_zero_when_the_account_has_no_completed_rides_in_range() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/earnings"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "from": "2026-07-01",
+                    "to": "2026-07-31",
+                    "currency": "COP",
+                    "total_earned": 0,
+                    "completed_rides": 0,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .driver_earnings(&sample_token(), "2026-07-01", "2026-07-31")
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.total_earned, 0);
+        assert_eq!(fetch.data.completed_rides, 0);
+    }
+
+    #[tokio::test]
+    async fn driver_earnings_returns_forbidden_on_403_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/earnings"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .driver_earnings(&sample_token(), "2026-07-01", "2026-07-31")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, GetDriverEarningsError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn driver_earnings_returns_validation_when_from_is_after_to() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/earnings"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "The to field must be a date after or equal to from.",
+                "errors": { "to": ["The to field must be a date after or equal to from."] },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .driver_earnings(&sample_token(), "2026-07-31", "2026-07-01")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, GetDriverEarningsError::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn driver_earnings_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/earnings"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/earnings"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "from": "2026-07-01",
+                    "to": "2026-07-31",
+                    "currency": "COP",
+                    "total_earned": 17500,
+                    "completed_rides": 2,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .driver_earnings(&sample_token(), "2026-07-01", "2026-07-31")
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data.total_earned, 17500);
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn driver_earnings_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/me/earnings"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .driver_earnings(&sample_token(), "2026-07-01", "2026-07-31")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, GetDriverEarningsError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn driver_earnings_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .driver_earnings(&sample_token(), "2026-07-01", "2026-07-31")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, GetDriverEarningsError::Network(_)));
     }
 
     #[tokio::test]

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -310,6 +310,21 @@ pub struct BroadcastAuthResponse {
     pub auth: String,
 }
 
+/// `openapi.yaml#/components/schemas/DriverEarningsSummary` — respuesta de
+/// `GET /api/v1/me/earnings` (historia #29). `from`/`to` vuelven tal como los
+/// normalizo el backend (`toDateString()`, formato `YYYY-MM-DD`), no
+/// necesariamente iguales en formato al string que mando el cliente en la
+/// query string. `total_earned` es un entero en la unidad minima de
+/// `currency`, mismo criterio que `RideEstimate::estimated_fare`.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct DriverEarningsSummary {
+    pub from: String,
+    pub to: String,
+    pub currency: String,
+    pub total_earned: i64,
+    pub completed_rides: u32,
+}
+
 /// Payload del evento `ride.requested`, publicado sobre el canal privado
 /// `driver.{id}` (`id` = `User.id` del conductor, no el de `driver_profiles`)
 /// cuando hay un viaje nuevo cerca (issue #16). Sin envelope `data`: viaja tal
@@ -700,6 +715,27 @@ mod tests {
                 status: PaymentStatus::Paid,
             })
         );
+    }
+
+    #[test]
+    fn deserializes_driver_earnings_summary_envelope() {
+        let json = r#"{
+            "data": {
+                "from": "2026-07-01",
+                "to": "2026-07-31",
+                "currency": "COP",
+                "total_earned": 17500,
+                "completed_rides": 2
+            }
+        }"#;
+
+        let envelope: DataEnvelope<DriverEarningsSummary> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(envelope.data.from, "2026-07-01");
+        assert_eq!(envelope.data.to, "2026-07-31");
+        assert_eq!(envelope.data.currency, "COP");
+        assert_eq!(envelope.data.total_earned, 17500);
+        assert_eq!(envelope.data.completed_rides, 2);
     }
 
     #[test]

--- a/crates/moto_ui/src/lib.rs
+++ b/crates/moto_ui/src/lib.rs
@@ -10,6 +10,7 @@ pub mod map;
 pub mod screens;
 
 pub use map::{MapMarker, MapView};
+pub use screens::driver_earnings::DriverEarningsScreen;
 pub use screens::login::LoginScreen;
 pub use screens::nearby_rides::NearbyRidesScreen;
 pub use screens::profile::ProfileScreen;
@@ -86,6 +87,7 @@ enum HomeSection {
     Vehicle,
     NearbyRides,
     RideHistory,
+    DriverEarnings,
 }
 
 /// Pantalla principal tras iniciar sesion: perfil (issue #9), tarifa
@@ -93,14 +95,16 @@ enum HomeSection {
 /// seccion — cerrar sesion debe estar disponible desde el momento en que hay
 /// una sesion iniciada.
 ///
-/// Las secciones de vehiculo (issues #11 y #12, `VehicleScreen`) y de
-/// solicitudes cercanas (issue #16, `NearbyRidesScreen`) solo se ofrecen
-/// cuando `session.user()` ya cargo (`GET /api/v1/me`, issue #9) y es una
-/// cuenta de conductor: un pasajero nunca ve esos botones, y
-/// estructuralmente no puede llegar a esas pantallas desde esta navegacion.
-/// El historial de viajes (issue #28, `RideHistoryScreen`) es al reves:
-/// solo se ofrece a pasajero — el equivalente para conductor es la historia
-/// #29, todavia sin implementar.
+/// Las secciones de vehiculo (issues #11 y #12, `VehicleScreen`), de
+/// solicitudes cercanas (issue #16, `NearbyRidesScreen`) y de historial y
+/// ganancias (historia #29, `DriverEarningsScreen`) solo se ofrecen cuando
+/// `session.user()` ya cargo (`GET /api/v1/me`, issue #9) y es una cuenta de
+/// conductor: un pasajero nunca ve esos botones, y estructuralmente no puede
+/// llegar a esas pantallas desde esta navegacion. El historial de viajes
+/// simple (issue #28, `RideHistoryScreen`) es al reves: solo se ofrece a
+/// pasajero — el equivalente para conductor no reutiliza esa pantalla porque
+/// tambien necesita el resumen de ganancias, asi que vive en
+/// `DriverEarningsScreen`.
 #[component]
 fn Home() -> Element {
     let api_client = use_context::<ApiClient>();
@@ -162,6 +166,12 @@ fn Home() -> Element {
                         onclick: move |_| section.set(HomeSection::NearbyRides),
                         "Solicitudes cercanas"
                     }
+                    button {
+                        r#type: "button",
+                        disabled: section() == HomeSection::DriverEarnings,
+                        onclick: move |_| section.set(HomeSection::DriverEarnings),
+                        "Historial y ganancias"
+                    }
                 } else {
                     button {
                         r#type: "button",
@@ -186,6 +196,9 @@ fn Home() -> Element {
                 },
                 HomeSection::RideHistory => rsx! {
                     RideHistoryScreen {}
+                },
+                HomeSection::DriverEarnings => rsx! {
+                    DriverEarningsScreen {}
                 },
             }
             button {

--- a/crates/moto_ui/src/screens/driver_earnings.rs
+++ b/crates/moto_ui/src/screens/driver_earnings.rs
@@ -1,0 +1,233 @@
+//! Pantalla de historial de viajes y ganancias (conductor) — historia #29.
+//!
+//! Dos secciones independientes, cada una con su propio fetch:
+//!
+//! - Historial: al entrar, consulta `GET /api/v1/me/rides`
+//!   (`ApiClient::ride_history`) — el mismo endpoint que usa
+//!   `RideHistoryScreen` para el pasajero, pero acá lista los viajes que le
+//!   asignaron al conductor (lo decide `ShowRideHistoryController` en el
+//!   backend según el rol de la cuenta). No repite la fila "Conductor: ..."
+//!   de `RideHistoryScreen`: el conductor ya sabe que el viaje es suyo, y el
+//!   backend no expone el nombre del pasajero (`RideResource` no lo publica).
+//! - Ganancias: el conductor elige un rango de fechas y consulta
+//!   `GET /api/v1/me/earnings` (`ApiClient::driver_earnings`) bajo demanda —
+//!   sin rango elegido no hay nada que consultar, así que no hay fetch
+//!   automático al entrar (a diferencia del historial).
+//!
+//! Un conductor sin viajes completados en el rango elegido recibe
+//! `total_earned`/`completed_rides` en cero desde el backend, no un error —
+//! esta pantalla lo distingue con un estado vacío explícito en vez de
+//! mostrar "0 COP" sin contexto (criterio de aceptación de la #29).
+
+use std::sync::Arc;
+
+use dioxus::prelude::*;
+use moto_core::api::{ApiClient, AuthenticatedRequestError, GetDriverEarningsError};
+use moto_core::models::{DriverEarningsSummary, Ride};
+use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
+
+use super::ride_history::ride_status_label;
+
+#[component]
+pub fn DriverEarningsScreen() -> Element {
+    rsx! {
+        div { class: "driver-earnings-screen",
+            h2 { "Historial de viajes y ganancias" }
+            DriverRideHistory {}
+            DriverEarningsSummaryForm {}
+        }
+    }
+}
+
+#[component]
+fn DriverRideHistory() -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut is_loading = use_signal(|| false);
+    let mut load_error = use_signal(|| None::<String>);
+    let mut rides = use_signal(Vec::<Ride>::new);
+    // Misma guarda que `RideHistoryScreen`: el efecto lee `session.token()`
+    // en su primera corrida, lo que lo suscribe a ese signal, y el fetch
+    // puede terminar escribiendo en `session` (refresh de token, logout) —
+    // sin esta bandera reprogramaria el efecto en un loop.
+    let mut has_fetched = use_signal(|| false);
+
+    use_effect(move || {
+        if has_fetched() {
+            return;
+        }
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        has_fetched.set(true);
+
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            load_error.set(None);
+
+            match api_client.ride_history(&token).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    rides.set(fetch.data);
+                }
+                Err(AuthenticatedRequestError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    load_error.set(Some(err.to_string()));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    });
+
+    rsx! {
+        section { class: "driver-ride-history",
+            h3 { "Viajes asignados" }
+            if is_loading() {
+                p { "Cargando..." }
+            } else if let Some(message) = load_error() {
+                p { class: "driver-ride-history-error", role: "alert", "{message}" }
+            } else if rides().is_empty() {
+                p { class: "driver-ride-history-empty", "Todavia no tienes viajes asignados." }
+            } else {
+                ul { class: "driver-ride-history-list",
+                    for ride in rides() {
+                        DriverRideHistoryRow { key: "{ride.id}", ride }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct DriverRideHistoryRowProps {
+    ride: Ride,
+}
+
+#[component]
+fn DriverRideHistoryRow(props: DriverRideHistoryRowProps) -> Element {
+    let ride = &props.ride;
+    let fare = ride.final_fare.unwrap_or(ride.estimated_fare);
+
+    rsx! {
+        li { class: "driver-ride-history-row",
+            p { class: "driver-ride-history-status", "{ride_status_label(ride.status)}" }
+            p { "Fecha: {ride.requested_at}" }
+            p { "Origen: {ride.origin.latitude}, {ride.origin.longitude}" }
+            p { "Destino: {ride.destination.latitude}, {ride.destination.longitude}" }
+            p { "Tarifa: {ride.currency} {fare}" }
+        }
+    }
+}
+
+#[component]
+fn DriverEarningsSummaryForm() -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut from = use_signal(String::new);
+    let mut to = use_signal(String::new);
+    let mut is_loading = use_signal(|| false);
+    let mut load_error = use_signal(|| None::<GetDriverEarningsError>);
+    let mut summary = use_signal(|| None::<DriverEarningsSummary>);
+
+    let on_submit = move |event: FormEvent| {
+        event.prevent_default();
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        let from_value = from();
+        let to_value = to();
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            load_error.set(None);
+            summary.set(None);
+
+            match api_client
+                .driver_earnings(&token, &from_value, &to_value)
+                .await
+            {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    summary.set(Some(fetch.data));
+                }
+                Err(GetDriverEarningsError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    load_error.set(Some(err));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    };
+
+    let can_submit = !from().trim().is_empty() && !to().trim().is_empty() && !is_loading();
+
+    rsx! {
+        section { class: "driver-earnings-summary",
+            h3 { "Resumen de ganancias" }
+            form { class: "driver-earnings-form", onsubmit: on_submit,
+                label { r#for: "driver-earnings-from", "Desde" }
+                input {
+                    id: "driver-earnings-from",
+                    r#type: "date",
+                    disabled: is_loading(),
+                    value: "{from}",
+                    oninput: move |event| from.set(event.value()),
+                }
+                label { r#for: "driver-earnings-to", "Hasta" }
+                input {
+                    id: "driver-earnings-to",
+                    r#type: "date",
+                    disabled: is_loading(),
+                    value: "{to}",
+                    oninput: move |event| to.set(event.value()),
+                }
+                button { r#type: "submit", disabled: !can_submit,
+                    if is_loading() {
+                        "Consultando..."
+                    } else {
+                        "Ver ganancias"
+                    }
+                }
+            }
+            if let Some(message) = load_error().as_ref().map(|err| err.to_string()) {
+                p { class: "driver-earnings-error", role: "alert", "{message}" }
+            } else if let Some(current) = summary() {
+                if current.completed_rides == 0 {
+                    p { class: "driver-earnings-empty",
+                        "No tienes viajes completados entre {current.from} y {current.to}."
+                    }
+                } else {
+                    dl { class: "driver-earnings-result",
+                        dt { "Total ganado" }
+                        dd { "{current.currency} {current.total_earned}" }
+                        dt { "Viajes completados" }
+                        dd { "{current.completed_rides}" }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/moto_ui/src/screens/mod.rs
+++ b/crates/moto_ui/src/screens/mod.rs
@@ -1,3 +1,4 @@
+pub mod driver_earnings;
 pub mod login;
 pub mod nearby_rides;
 pub mod profile;

--- a/crates/moto_ui/src/screens/ride_history.rs
+++ b/crates/moto_ui/src/screens/ride_history.rs
@@ -7,8 +7,9 @@
 //! ese caso se distingue con un estado vacio explicito en vez de mostrar la
 //! lista en blanco (criterio de aceptacion del issue).
 //!
-//! El equivalente para conductor (historial + resumen de ganancias) es la
-//! historia #29, fuera de alcance aca — `Home` (`moto_ui/src/lib.rs`) solo
+//! El equivalente para conductor (historial + resumen de ganancias) es
+//! `DriverEarningsScreen` (historia #29), que reutiliza `ride_status_label`
+//! de aca pero tiene su propio fetch — `Home` (`moto_ui/src/lib.rs`) solo
 //! ofrece esta pestana a cuentas de pasajero.
 
 use std::sync::Arc;
@@ -114,8 +115,10 @@ fn RideHistoryRow(props: RideHistoryRowProps) -> Element {
     }
 }
 
-/// Texto del estado de un viaje del historial, tal como lo ve el pasajero.
-fn ride_status_label(status: RideStatus) -> &'static str {
+/// Texto del estado de un viaje del historial. Compartido con
+/// `DriverEarningsScreen` (historia #29): el estado de un viaje se lee igual
+/// sin importar si lo ve el pasajero o el conductor asignado.
+pub(crate) fn ride_status_label(status: RideStatus) -> &'static str {
     match status {
         RideStatus::Requested => "Esperando conductor",
         RideStatus::Accepted => "Conductor asignado",


### PR DESCRIPTION
Closes #29

## Que hace
Agrega la pantalla de historial de viajes y resumen de ganancias del
conductor, consumiendo `GET /api/v1/me/rides` y `GET /api/v1/me/earnings`
del backend (`Back_App_MotoCarros`), verificados directamente contra el
codigo del backend (controllers, requests, resources, tests de feature) ya
que ambos endpoints ya existen y estan implementados ahi.

- `ApiClient::driver_earnings` (`crates/moto_core/src/api.rs`): nuevo
  wrapper GET con query string (`from`/`to`) y reintento por refresh de
  token, mismo patron que `get_vehicle`. Distingue `Forbidden` (cuenta no
  conductora) de `Validation` (from/to invalidos o `to` anterior a `from`,
  mismo 422 para los tres casos segun `ShowDriverEarningsRequest` del
  backend).
- `DriverEarningsSummary` (`crates/moto_core/src/models.rs`): nuevo modelo
  que refleja `DriverEarningsSummaryResource` del backend
  (`from`/`to`/`currency`/`total_earned`/`completed_rides`).
- `DriverEarningsScreen` (`crates/moto_ui/src/screens/driver_earnings.rs`):
  pantalla nueva con dos secciones independientes:
  - Historial: fetch-on-mount de `ApiClient::ride_history` (mismo endpoint
    que ya usaba `RideHistoryScreen` para pasajero — el backend decide la
    relacion segun el rol), listando los viajes asignados al conductor sin
    repetir la fila "Conductor: ..." de la version de pasajero (el backend
    no expone el nombre del pasajero en `RideResource`).
  - Ganancias: formulario con `<input type="date">` para `from`/`to` y
    boton para consultar bajo demanda (sin fetch automatico: sin rango
    elegido no hay nada que pedir). Un resultado con `completed_rides == 0`
    muestra un estado vacio explicito en vez de "0 COP" sin contexto.
- `ride_status_label` (`crates/moto_ui/src/screens/ride_history.rs`): se
  hizo `pub(crate)` para reutilizarla desde la nueva pantalla, en vez de
  duplicar el mapeo de estados.
- `Home` (`crates/moto_ui/src/lib.rs`): nueva pestana "Historial y
  ganancias", ofrecida solo a cuentas de conductor.
- `Cargo.toml` (workspace): agregada la feature `query` de `reqwest` — el
  cliente HTTP no traia `serde_urlencoded` sin ella, necesaria para el
  query string de `driver_earnings`.

## Como se probo
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`
- `cargo test --workspace --exclude mobile` (214 tests, incluye 8 tests
  nuevos de `ApiClient::driver_earnings` con HTTP mockeado — rango con
  ganancias, rango sin viajes completados, 403, 422, refresh de token en
  401, sesion no renovable, y error de red — y un test de deserializacion
  de `DriverEarningsSummary`)
- `dx build --platform web --package web`

## Decisiones y riesgos
- No hay libreria de fechas en el workspace (ni `chrono` ni `time`): en vez
  de agregar una dependencia nueva solo para calcular un rango por defecto
  ("mes actual"), el formulario arranca vacio y el boton de consulta queda
  deshabilitado hasta que el conductor elija ambas fechas. El backend ya
  valida formato y orden (`from`/`to`), asi que el cliente no duplica esa
  regla.
- No reutilice `RideHistoryScreen` tal cual para el conductor: esa pantalla
  esta documentada como exclusiva de pasajero (incluye la fila
  "Conductor: ...", que no aplica cuando quien mira es el propio
  conductor). En su lugar, `DriverEarningsScreen` tiene su propio fetch de
  historial con una fila mas simple, reutilizando solo `ride_status_label`.
- `GetDriverEarningsError::Validation` no distingue los tres casos posibles
  (from/to ausentes, formato invalido, `to` anterior a `from`): el backend
  responde el mismo 422 para los tres a proposito, mismo criterio que el
  resto de los errores de validacion de este cliente (ver
  `EstimateRideError`, `RequestRideError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)