### PR TITLE
feat(#25): ver recibo del viaje completado

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -8,8 +8,8 @@ use crate::models::{
     ApiErrorBody, AuthToken, AuthenticatedUser, BroadcastAuthPayload, BroadcastAuthResponse,
     Coordinates, DataEnvelope, DriverEarningsSummary, LoginPayload, RateDriverPayload,
     RegisterDriverPayload, RegisterPassengerPayload, RegisterVehiclePayload, Ride,
-    RideCancellation, RideEstimate, RideEstimateRequestPayload, RideRating, RideRequestPayload,
-    UpdateProfilePayload, UpdateVehiclePayload, User, Vehicle,
+    RideCancellation, RideEstimate, RideEstimateRequestPayload, RideRating, RideReceipt,
+    RideRequestPayload, UpdateProfilePayload, UpdateVehiclePayload, User, Vehicle,
 };
 
 #[cfg(test)]
@@ -937,6 +937,50 @@ impl std::fmt::Display for GetRideError {
 
 impl std::error::Error for GetRideError {}
 
+/// Fallos posibles de `GET /api/v1/rides/{ride}/receipt` (historia #25).
+///
+/// `Forbidden` cubre tanto a otro pasajero como al conductor asignado: el
+/// recibo es lo que se le cobro al pasajero, no un dato del viaje en si, asi
+/// que a diferencia de `GetRideError` el conductor tambien recibe 403
+/// (`RidePolicy::viewReceipt` en el backend). `Validation` cubre que el
+/// viaje todavia no este `completed`, o que no tenga un pago procesado
+/// todavia: el backend responde el mismo 422 para ambos casos a proposito
+/// (ver `openapi.yaml`), asi que el cliente no los distingue.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GetReceiptError {
+    Forbidden,
+    /// No existe ningun viaje con ese id.
+    NotFound,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for GetReceiptError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GetReceiptError::Forbidden => write!(f, "Este recibo no te pertenece."),
+            GetReceiptError::NotFound => write!(f, "El viaje ya no existe."),
+            GetReceiptError::Validation(body) => write!(f, "{}", body.message),
+            GetReceiptError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            GetReceiptError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            GetReceiptError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GetReceiptError {}
+
 /// Fallos posibles de `POST /api/v1/broadcasting/auth` (issue #5).
 ///
 /// A diferencia del resto de las requests autenticadas, esta nunca reintenta
@@ -1119,6 +1163,14 @@ enum GetRideOutcome<T> {
     Unauthorized,
     Forbidden,
     NotFound,
+}
+
+enum GetReceiptOutcome<T> {
+    Success(T),
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    Validation(ApiErrorBody),
 }
 
 enum GetEarningsOutcome<T> {
@@ -2795,6 +2847,93 @@ impl ApiClient {
             403 => Ok(GetRideOutcome::Forbidden),
             404 => Ok(GetRideOutcome::NotFound),
             other => Err(GetRideError::Unexpected(other)),
+        }
+    }
+
+    /// `GET /api/v1/rides/{ride}/receipt` — historia #25. Se pide bajo
+    /// demanda cuando el pasajero abre el recibo de un viaje completado
+    /// desde `RideHistoryScreen` (`moto_ui`), sin fetch automatico. Mismo
+    /// reparto que `get_ride`: reintenta una vez con refresh de token ante
+    /// un 401; un 403 (recibo ajeno), 404 (no existe) o 422 (todavia no
+    /// disponible) nunca se reintentan.
+    pub async fn ride_receipt(
+        &self,
+        token: &AuthToken,
+        ride_id: u64,
+    ) -> Result<AuthenticatedFetch<RideReceipt>, GetReceiptError> {
+        match self
+            .get_receipt_with_token(ride_id, &token.access_token)
+            .await?
+        {
+            GetReceiptOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            GetReceiptOutcome::Forbidden => return Err(GetReceiptError::Forbidden),
+            GetReceiptOutcome::NotFound => return Err(GetReceiptError::NotFound),
+            GetReceiptOutcome::Validation(body) => return Err(GetReceiptError::Validation(body)),
+            GetReceiptOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| GetReceiptError::SessionExpired)?;
+
+        match self
+            .get_receipt_with_token(ride_id, &renewed.access_token)
+            .await?
+        {
+            GetReceiptOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            GetReceiptOutcome::Forbidden => Err(GetReceiptError::Forbidden),
+            GetReceiptOutcome::NotFound => Err(GetReceiptError::NotFound),
+            GetReceiptOutcome::Validation(body) => Err(GetReceiptError::Validation(body)),
+            GetReceiptOutcome::Unauthorized => Err(GetReceiptError::SessionExpired),
+        }
+    }
+
+    async fn get_receipt_with_token(
+        &self,
+        ride_id: u64,
+        access_token: &str,
+    ) -> Result<GetReceiptOutcome<RideReceipt>, GetReceiptError> {
+        let url = format!("{}/api/v1/rides/{}/receipt", self.base_url, ride_id);
+
+        let response = self
+            .http
+            .get(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|err| GetReceiptError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<RideReceipt> = response
+                .json()
+                .await
+                .map_err(|err| GetReceiptError::Network(err.to_string()))?;
+            return Ok(GetReceiptOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(GetReceiptOutcome::Unauthorized),
+            403 => Ok(GetReceiptOutcome::Forbidden),
+            404 => Ok(GetReceiptOutcome::NotFound),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| GetReceiptError::Network(err.to_string()))?;
+                Ok(GetReceiptOutcome::Validation(body))
+            }
+            other => Err(GetReceiptError::Unexpected(other)),
         }
     }
 
@@ -6655,6 +6794,187 @@ mod tests {
         let error = client.get_ride(&sample_token(), 1).await.unwrap_err();
 
         assert!(matches!(error, GetRideError::Network(_)));
+    }
+
+    fn sample_receipt_json() -> serde_json::Value {
+        serde_json::json!({
+            "ride_id": 1,
+            "currency": "COP",
+            "base_fare": 1500,
+            "distance_fare": 5937,
+            "time_fare": 1000,
+            "waiting_fee": 0,
+            "subtotal": 8437,
+            "minimum_applied": false,
+            "total": 8450,
+            "payment_status": "paid",
+            "completed_at": "2026-07-31T14:19:05+00:00",
+        })
+    }
+
+    #[tokio::test]
+    async fn ride_receipt_returns_the_charge_breakdown() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/1/receipt"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": sample_receipt_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.ride_receipt(&sample_token(), 1).await.unwrap();
+
+        assert_eq!(fetch.data.ride_id, 1);
+        assert_eq!(fetch.data.total, 8450);
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn ride_receipt_returns_forbidden_on_403_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/1/receipt"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "message": "This action is unauthorized.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.ride_receipt(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(error, GetReceiptError::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn ride_receipt_returns_not_found_on_404_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/999/receipt"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "message": "No query results for model [App\\Models\\Ride] 999.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.ride_receipt(&sample_token(), 999).await.unwrap_err();
+
+        assert_eq!(error, GetReceiptError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn ride_receipt_returns_validation_when_the_ride_has_no_processed_payment_yet() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/1/receipt"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "El recibo todavia no esta disponible para este viaje.",
+                "errors": { "ride": ["El recibo todavia no esta disponible para este viaje."] },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.ride_receipt(&sample_token(), 1).await.unwrap_err();
+
+        assert!(matches!(error, GetReceiptError::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn ride_receipt_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/1/receipt"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/1/receipt"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": sample_receipt_json(),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client.ride_receipt(&sample_token(), 1).await.unwrap();
+
+        assert_eq!(fetch.data.ride_id, 1);
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn ride_receipt_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/rides/1/receipt"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client.ride_receipt(&sample_token(), 1).await.unwrap_err();
+
+        assert_eq!(error, GetReceiptError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn ride_receipt_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client.ride_receipt(&sample_token(), 1).await.unwrap_err();
+
+        assert!(matches!(error, GetReceiptError::Network(_)));
     }
 
     #[tokio::test]

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -268,6 +268,27 @@ pub struct RideCancellation {
     pub cancellation_fee_applies: Option<bool>,
 }
 
+/// `openapi.yaml#/components/schemas/RideReceipt` — respuesta de
+/// `GET /api/v1/rides/{ride}/receipt` (historia #25): el desglose que
+/// produjo el cobro publicado en `Ride.payment`/`Ride.final_fare`. A
+/// diferencia de `Payment` embebido en `Ride`, repite `currency` y `total`:
+/// este es el recurso principal de la respuesta y tiene que bastarse solo,
+/// sin depender de que el cliente ya tenga el viaje cargado.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct RideReceipt {
+    pub ride_id: u64,
+    pub currency: String,
+    pub base_fare: i64,
+    pub distance_fare: i64,
+    pub time_fare: i64,
+    pub waiting_fee: i64,
+    pub subtotal: i64,
+    pub minimum_applied: bool,
+    pub total: i64,
+    pub payment_status: PaymentStatus,
+    pub completed_at: String,
+}
+
 /// Body de `POST /api/v1/rides/{ride}/rate-driver` (historia #26). `comment`
 /// se omite del JSON cuando es `None` en vez de mandarse como `null`: el
 /// backend lo declara `nullable` pero no `required`, y el resto de los
@@ -736,6 +757,33 @@ mod tests {
         assert_eq!(envelope.data.currency, "COP");
         assert_eq!(envelope.data.total_earned, 17500);
         assert_eq!(envelope.data.completed_rides, 2);
+    }
+
+    #[test]
+    fn deserializes_ride_receipt_envelope() {
+        let json = r#"{
+            "data": {
+                "ride_id": 1,
+                "currency": "COP",
+                "base_fare": 1500,
+                "distance_fare": 5937,
+                "time_fare": 1000,
+                "waiting_fee": 0,
+                "subtotal": 8437,
+                "minimum_applied": false,
+                "total": 8450,
+                "payment_status": "paid",
+                "completed_at": "2026-07-31T14:19:05+00:00"
+            }
+        }"#;
+
+        let envelope: DataEnvelope<RideReceipt> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(envelope.data.ride_id, 1);
+        assert_eq!(envelope.data.currency, "COP");
+        assert_eq!(envelope.data.total, 8450);
+        assert!(!envelope.data.minimum_applied);
+        assert_eq!(envelope.data.payment_status, PaymentStatus::Paid);
     }
 
     #[test]

--- a/crates/moto_ui/src/screens/mod.rs
+++ b/crates/moto_ui/src/screens/mod.rs
@@ -7,4 +7,5 @@ pub mod register_passenger;
 pub mod register_vehicle;
 pub mod ride_estimate;
 pub mod ride_history;
+pub mod ride_receipt;
 pub mod vehicle;

--- a/crates/moto_ui/src/screens/ride_history.rs
+++ b/crates/moto_ui/src/screens/ride_history.rs
@@ -11,6 +11,11 @@
 //! `DriverEarningsScreen` (historia #29), que reutiliza `ride_status_label`
 //! de aca pero tiene su propio fetch — `Home` (`moto_ui/src/lib.rs`) solo
 //! ofrece esta pestana a cuentas de pasajero.
+//!
+//! Cada viaje `completed` ofrece un "Ver recibo" que abre `RideReceiptScreen`
+//! (historia #25) para ese `ride_id`, en vez de una pantalla aparte
+//! registrada en `Home`: el recibo solo tiene sentido en el contexto de un
+//! viaje de este historial, nunca como seccion propia de la navegacion.
 
 use std::sync::Arc;
 
@@ -19,6 +24,8 @@ use moto_core::api::{ApiClient, AuthenticatedRequestError};
 use moto_core::models::{Ride, RideStatus};
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
+
+use super::ride_receipt::RideReceiptScreen;
 
 #[component]
 pub fn RideHistoryScreen() -> Element {
@@ -34,6 +41,10 @@ pub fn RideHistoryScreen() -> Element {
     // signal, y el fetch puede terminar escribiendo en `session` (refresh de
     // token, logout) — sin esta bandera reprogramaria el efecto en un loop.
     let mut has_fetched = use_signal(|| false);
+    // `Some(ride_id)` mientras se ve el recibo de ese viaje (historia #25):
+    // reemplaza la lista en vez de superponerse, mismo patron de navegacion
+    // manual por signal que `HomeSection` en `moto_ui/src/lib.rs`.
+    let mut viewing_receipt = use_signal(|| None::<u64>);
 
     use_effect(move || {
         if has_fetched() {
@@ -74,7 +85,12 @@ pub fn RideHistoryScreen() -> Element {
     rsx! {
         div { class: "ride-history-screen",
             h2 { "Historial de viajes" }
-            if is_loading() {
+            if let Some(ride_id) = viewing_receipt() {
+                RideReceiptScreen {
+                    ride_id,
+                    on_close: move |_| viewing_receipt.set(None),
+                }
+            } else if is_loading() {
                 p { "Cargando..." }
             } else if let Some(message) = load_error() {
                 p { class: "ride-history-error", role: "alert", "{message}" }
@@ -83,7 +99,11 @@ pub fn RideHistoryScreen() -> Element {
             } else {
                 ul { class: "ride-history-list",
                     for ride in rides() {
-                        RideHistoryRow { key: "{ride.id}", ride }
+                        RideHistoryRow {
+                            key: "{ride.id}",
+                            ride,
+                            on_view_receipt: move |ride_id| viewing_receipt.set(Some(ride_id)),
+                        }
                     }
                 }
             }
@@ -94,12 +114,14 @@ pub fn RideHistoryScreen() -> Element {
 #[derive(Props, Clone, PartialEq)]
 struct RideHistoryRowProps {
     ride: Ride,
+    on_view_receipt: EventHandler<u64>,
 }
 
 #[component]
 fn RideHistoryRow(props: RideHistoryRowProps) -> Element {
     let ride = &props.ride;
     let fare = ride.final_fare.unwrap_or(ride.estimated_fare);
+    let ride_id = ride.id;
 
     rsx! {
         li { class: "ride-history-row",
@@ -110,6 +132,13 @@ fn RideHistoryRow(props: RideHistoryRowProps) -> Element {
             p { "Tarifa: {ride.currency} {fare}" }
             if let Some(driver) = &ride.driver {
                 p { "Conductor: {driver.name}" }
+            }
+            if ride.status == RideStatus::Completed {
+                button {
+                    r#type: "button",
+                    onclick: move |_| props.on_view_receipt.call(ride_id),
+                    "Ver recibo"
+                }
             }
         }
     }

--- a/crates/moto_ui/src/screens/ride_receipt.rs
+++ b/crates/moto_ui/src/screens/ride_receipt.rs
@@ -1,0 +1,115 @@
+//! Pantalla de recibo del viaje completado (pasajero) — historia #25.
+//!
+//! Se abre desde `RideHistoryScreen` con el "Ver recibo" de un viaje
+//! `completed`: consulta `GET /api/v1/rides/{ride}/receipt`
+//! (`ApiClient::ride_receipt`) bajo demanda, mismo criterio que
+//! `DriverEarningsSummaryForm` (sin fetch automatico al entrar, porque
+//! depende de un `ride_id` que solo se conoce al abrir esta pantalla). Un
+//! viaje completado pero sin pago procesado todavia responde 422
+//! (`ShowRideReceiptController` en el backend) — ese caso se distingue del
+//! recibo con un mensaje explicito, nunca mostrando un recibo vacio o roto
+//! (criterio de aceptacion de la #25).
+
+use std::sync::Arc;
+
+use dioxus::prelude::*;
+use moto_core::api::{ApiClient, GetReceiptError};
+use moto_core::models::RideReceipt;
+use moto_core::state::SessionState;
+use moto_core::storage::TokenStorage;
+
+#[derive(Props, Clone, PartialEq)]
+pub struct RideReceiptScreenProps {
+    pub ride_id: u64,
+    /// Se dispara cuando el pasajero pide volver al historial.
+    pub on_close: EventHandler<()>,
+}
+
+#[component]
+pub fn RideReceiptScreen(props: RideReceiptScreenProps) -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut is_loading = use_signal(|| false);
+    let mut load_error = use_signal(|| None::<GetReceiptError>);
+    let mut receipt = use_signal(|| None::<RideReceipt>);
+    // Misma guarda que `RideHistoryScreen`: el efecto lee `session.token()`
+    // en su primera corrida, lo que lo suscribe a ese signal, y el fetch
+    // puede terminar escribiendo en `session` (refresh de token, logout) —
+    // sin esta bandera reprogramaria el efecto en un loop.
+    let mut has_fetched = use_signal(|| false);
+
+    let ride_id = props.ride_id;
+
+    use_effect(move || {
+        if has_fetched() {
+            return;
+        }
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        has_fetched.set(true);
+
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_loading.set(true);
+            load_error.set(None);
+
+            match api_client.ride_receipt(&token, ride_id).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    receipt.set(Some(fetch.data));
+                }
+                Err(GetReceiptError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    load_error.set(Some(err));
+                }
+            }
+
+            is_loading.set(false);
+        });
+    });
+
+    rsx! {
+        div { class: "ride-receipt-screen",
+            h3 { "Recibo del viaje" }
+            if is_loading() {
+                p { "Cargando..." }
+            } else if matches!(load_error(), Some(GetReceiptError::Validation(_))) {
+                p { class: "ride-receipt-unavailable",
+                    "El recibo todavia no esta disponible para este viaje."
+                }
+            } else if let Some(message) = load_error().as_ref().map(|err| err.to_string()) {
+                p { class: "ride-receipt-error", role: "alert", "{message}" }
+            } else if let Some(current) = receipt() {
+                dl { class: "ride-receipt-detail",
+                    dt { "Tarifa base" }
+                    dd { "{current.currency} {current.base_fare}" }
+                    dt { "Distancia" }
+                    dd { "{current.currency} {current.distance_fare}" }
+                    dt { "Tiempo" }
+                    dd { "{current.currency} {current.time_fare}" }
+                    dt { "Espera" }
+                    dd { "{current.currency} {current.waiting_fee}" }
+                    dt { "Total" }
+                    dd { "{current.currency} {current.total}" }
+                    dt { "Fecha" }
+                    dd { "{current.completed_at}" }
+                }
+            }
+            button {
+                r#type: "button",
+                onclick: move |_| props.on_close.call(()),
+                "Volver"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #25

## Que hace

- `moto_core::models::RideReceipt` -- refleja `openapi.yaml#/components/schemas/RideReceipt` del backend.
- `moto_core::api::ApiClient::ride_receipt` + `GetReceiptError`, mismo patron de reintento con refresh de token que `get_ride`/`driver_earnings`. `Forbidden` cubre al conductor asignado (el recibo es exclusivo del pasajero). `Validation` cubre el 422 de "viaje no completado / sin pago procesado todavia".
- `moto_ui::screens::ride_receipt::RideReceiptScreen`, fetch bajo demanda.
- `RideHistoryScreen`: cada viaje `completed` tiene un boton "Ver recibo"; el 422 se muestra como mensaje claro, nunca como recibo vacio/roto.
- Tests unitarios para el fetch (exito, 403, 404, 422, retry-on-401, session-expired, network error) y la deserializacion del envelope.

## Como se probo

`cargo fmt --all -- --check`, `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings`, `cargo test --workspace --exclude mobile`, y build de `web` para `wasm32-unknown-unknown`: los cuatro en verde.

## Decisiones y riesgos

Rama generada por `front_dev`, que no pudo empujarla por un crash
intermitente del entorno local (`STATUS_ACCESS_VIOLATION`, no
reproducible en esta corrida). Se verifico el gate completo y se
completo el push manualmente para no perder el trabajo.