### PR TITLE
feat(#60): confirmar el número de celular con un código por SMS

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -6,10 +6,11 @@
 
 use crate::models::{
     ApiErrorBody, AuthToken, AuthenticatedUser, BroadcastAuthPayload, BroadcastAuthResponse,
-    Coordinates, DataEnvelope, DriverEarningsSummary, LoginPayload, RateDriverPayload,
-    RegisterDriverPayload, RegisterPassengerPayload, RegisterVehiclePayload, Ride,
-    RideCancellation, RideEstimate, RideEstimateRequestPayload, RideRating, RideReceipt,
-    RideRequestPayload, UpdateProfilePayload, UpdateVehiclePayload, User, Vehicle,
+    ConfirmPhoneVerificationPayload, Coordinates, DataEnvelope, DriverEarningsSummary,
+    LoginPayload, RateDriverPayload, RegisterDriverPayload, RegisterPassengerPayload,
+    RegisterVehiclePayload, Ride, RideCancellation, RideEstimate, RideEstimateRequestPayload,
+    RideRating, RideReceipt, RideRequestPayload, UpdateProfilePayload, UpdateVehiclePayload, User,
+    Vehicle,
 };
 
 #[cfg(test)]
@@ -330,6 +331,99 @@ impl UpdateProfileError {
     pub fn field_message(&self, field: &str) -> Option<String> {
         match self {
             UpdateProfileError::Validation(body) => body
+                .errors
+                .as_ref()
+                .and_then(|errors| errors.get(field))
+                .and_then(|messages| messages.first())
+                .cloned(),
+            _ => None,
+        }
+    }
+}
+
+/// Fallos posibles de `POST /api/v1/me/phone/verification`.
+///
+/// No hay validacion de entrada del lado del cliente: la request no lleva
+/// cuerpo, todo lo que puede fallar es del servidor.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RequestPhoneVerificationError {
+    /// Se supero el limite de 3 solicitudes cada 10 minutos
+    /// (`throttle:phone-verification` en el backend).
+    RateLimited,
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for RequestPhoneVerificationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequestPhoneVerificationError::RateLimited => write!(
+                f,
+                "Ya pediste varios codigos seguidos. Espera unos minutos e intenta de nuevo."
+            ),
+            RequestPhoneVerificationError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            RequestPhoneVerificationError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            RequestPhoneVerificationError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RequestPhoneVerificationError {}
+
+/// Fallos posibles de `POST /api/v1/me/phone/verification/confirm`.
+///
+/// El backend responde 422 bajo la clave `code` para las cuatro causas
+/// posibles (no hay verificacion pendiente, vencio, se agotaron los
+/// intentos, o el valor no coincide) — el cliente no las distingue porque
+/// para el usuario todas piden lo mismo: pedir un codigo nuevo.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfirmPhoneVerificationError {
+    EmptyCode,
+    Validation(ApiErrorBody),
+    SessionExpired,
+    Network(String),
+    Unexpected(u16),
+}
+
+impl std::fmt::Display for ConfirmPhoneVerificationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfirmPhoneVerificationError::EmptyCode => write!(f, "Ingresa el codigo recibido."),
+            ConfirmPhoneVerificationError::Validation(body) => write!(f, "{}", body.message),
+            ConfirmPhoneVerificationError::SessionExpired => {
+                write!(f, "La sesion expiro. Inicia sesion de nuevo.")
+            }
+            ConfirmPhoneVerificationError::Network(_) => {
+                write!(
+                    f,
+                    "No se pudo conectar con el servidor. Revisa tu conexion."
+                )
+            }
+            ConfirmPhoneVerificationError::Unexpected(status) => {
+                write!(f, "Ocurrio un error inesperado (codigo {status}).")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfirmPhoneVerificationError {}
+
+impl ConfirmPhoneVerificationError {
+    /// Mensaje de validacion especifico para `field`, igual que
+    /// `UpdateProfileError::field_message`.
+    pub fn field_message(&self, field: &str) -> Option<String> {
+        match self {
+            ConfirmPhoneVerificationError::Validation(body) => body
                 .errors
                 .as_ref()
                 .and_then(|errors| errors.get(field))
@@ -1080,6 +1174,15 @@ enum PostOutcome<T> {
     Validation(ApiErrorBody),
 }
 
+/// A diferencia de `PostOutcome`, esta request no tiene cuerpo de exito (204)
+/// ni cuerpo de validacion (no hay campos que validar) — lo unico que puede
+/// pasar del lado del servidor es autenticacion, limite de tasa, o exito.
+enum PhoneVerificationRequestOutcome {
+    Success,
+    Unauthorized,
+    RateLimited,
+}
+
 enum PostRideOutcome<T> {
     Success(T),
     Unauthorized,
@@ -1733,6 +1836,178 @@ impl ApiClient {
                 Ok(PatchOutcome::Validation(body))
             }
             other => Err(UpdateProfileError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/me/phone/verification` — issue #69 del backend. Genera
+    /// un codigo de verificacion y lo manda por SMS al celular de la cuenta.
+    /// Pedir uno nuevo reemplaza cualquier codigo vigente anterior — no hay
+    /// nada que el cliente deba limpiar antes de llamarlo de nuevo.
+    ///
+    /// Reintenta una vez con refresh de token ante un 401, igual que
+    /// `update_profile`; un 429 (limite de 3 cada 10 minutos) nunca se
+    /// reintenta.
+    pub async fn request_phone_verification(
+        &self,
+        token: &AuthToken,
+    ) -> Result<AuthenticatedFetch<()>, RequestPhoneVerificationError> {
+        match self
+            .post_phone_verification_request(&token.access_token)
+            .await?
+        {
+            PhoneVerificationRequestOutcome::Success => {
+                return Ok(AuthenticatedFetch {
+                    data: (),
+                    refreshed_token: None,
+                });
+            }
+            PhoneVerificationRequestOutcome::RateLimited => {
+                return Err(RequestPhoneVerificationError::RateLimited);
+            }
+            PhoneVerificationRequestOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| RequestPhoneVerificationError::SessionExpired)?;
+
+        match self
+            .post_phone_verification_request(&renewed.access_token)
+            .await?
+        {
+            PhoneVerificationRequestOutcome::Success => Ok(AuthenticatedFetch {
+                data: (),
+                refreshed_token: Some(renewed),
+            }),
+            PhoneVerificationRequestOutcome::RateLimited => {
+                Err(RequestPhoneVerificationError::RateLimited)
+            }
+            PhoneVerificationRequestOutcome::Unauthorized => {
+                Err(RequestPhoneVerificationError::SessionExpired)
+            }
+        }
+    }
+
+    async fn post_phone_verification_request(
+        &self,
+        access_token: &str,
+    ) -> Result<PhoneVerificationRequestOutcome, RequestPhoneVerificationError> {
+        let url = format!("{}/api/v1/me/phone/verification", self.base_url);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|err| RequestPhoneVerificationError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            return Ok(PhoneVerificationRequestOutcome::Success);
+        }
+
+        match status.as_u16() {
+            401 => Ok(PhoneVerificationRequestOutcome::Unauthorized),
+            429 => Ok(PhoneVerificationRequestOutcome::RateLimited),
+            other => Err(RequestPhoneVerificationError::Unexpected(other)),
+        }
+    }
+
+    /// `POST /api/v1/me/phone/verification/confirm` — issue #69 del backend.
+    /// Devuelve la cuenta actualizada (`phone_verified: true` si el codigo
+    /// era correcto) para que la UI no tenga que pedir `GET /me` aparte.
+    ///
+    /// Reintenta una vez con refresh de token ante un 401, igual que
+    /// `update_profile`; un 422 (codigo incorrecto, vencido, o intentos
+    /// agotados) nunca se reintenta — reintentar mandaria el mismo codigo
+    /// otra vez y solo gastaria otro intento.
+    pub async fn confirm_phone_verification(
+        &self,
+        token: &AuthToken,
+        code: &str,
+    ) -> Result<AuthenticatedFetch<User>, ConfirmPhoneVerificationError> {
+        let code = code.trim();
+        if code.is_empty() {
+            return Err(ConfirmPhoneVerificationError::EmptyCode);
+        }
+
+        let payload = ConfirmPhoneVerificationPayload {
+            code: code.to_string(),
+        };
+
+        match self
+            .post_phone_verification_confirm(&token.access_token, &payload)
+            .await?
+        {
+            PostOutcome::Success(data) => {
+                return Ok(AuthenticatedFetch {
+                    data,
+                    refreshed_token: None,
+                });
+            }
+            PostOutcome::Validation(body) => {
+                return Err(ConfirmPhoneVerificationError::Validation(body));
+            }
+            PostOutcome::Unauthorized => {}
+        }
+
+        let renewed = self
+            .refresh(&token.access_token)
+            .await
+            .map_err(|_| ConfirmPhoneVerificationError::SessionExpired)?;
+
+        match self
+            .post_phone_verification_confirm(&renewed.access_token, &payload)
+            .await?
+        {
+            PostOutcome::Success(data) => Ok(AuthenticatedFetch {
+                data,
+                refreshed_token: Some(renewed),
+            }),
+            PostOutcome::Validation(body) => Err(ConfirmPhoneVerificationError::Validation(body)),
+            PostOutcome::Unauthorized => Err(ConfirmPhoneVerificationError::SessionExpired),
+        }
+    }
+
+    async fn post_phone_verification_confirm(
+        &self,
+        access_token: &str,
+        body: &ConfirmPhoneVerificationPayload,
+    ) -> Result<PostOutcome<User>, ConfirmPhoneVerificationError> {
+        let url = format!("{}/api/v1/me/phone/verification/confirm", self.base_url);
+
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(access_token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|err| ConfirmPhoneVerificationError::Network(err.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let envelope: DataEnvelope<User> = response
+                .json()
+                .await
+                .map_err(|err| ConfirmPhoneVerificationError::Network(err.to_string()))?;
+            return Ok(PostOutcome::Success(envelope.data));
+        }
+
+        match status.as_u16() {
+            401 => Ok(PostOutcome::Unauthorized),
+            422 => {
+                let body: ApiErrorBody = response
+                    .json()
+                    .await
+                    .map_err(|err| ConfirmPhoneVerificationError::Network(err.to_string()))?;
+                Ok(PostOutcome::Validation(body))
+            }
+            other => Err(ConfirmPhoneVerificationError::Unexpected(other)),
         }
     }
 
@@ -3033,6 +3308,7 @@ mod tests {
                         "name": "Ana Garcia",
                         "email": "ana@example.com",
                         "phone": "+573001234567",
+                        "phone_verified": false,
                         "role": "passenger",
                     },
                     "token": {
@@ -3174,6 +3450,7 @@ mod tests {
                         "name": "Ana Garcia",
                         "email": "ana@example.com",
                         "phone": "+573001234567",
+                        "phone_verified": false,
                         "role": "passenger",
                     },
                     "token": {
@@ -3432,6 +3709,7 @@ mod tests {
                         "name": "Carlos Perez",
                         "email": "carlos@example.com",
                         "phone": "+573001234567",
+                        "phone_verified": false,
                         "role": "driver",
                     },
                     "token": {
@@ -3771,6 +4049,7 @@ mod tests {
                     "name": "Ana Garcia",
                     "email": "ana@example.com",
                     "phone": "+573001234567",
+                    "phone_verified": false,
                     "role": "passenger",
                 }
             })))
@@ -4192,6 +4471,7 @@ mod tests {
                     "name": "Ana Garcia Perez",
                     "email": "ana@example.com",
                     "phone": "+573007654321",
+                    "phone_verified": false,
                     "role": "passenger",
                 }
             })))
@@ -4303,6 +4583,7 @@ mod tests {
                     "name": "Ana Garcia Perez",
                     "email": "ana@example.com",
                     "phone": "+573001234567",
+                    "phone_verified": false,
                     "role": "passenger",
                 }
             })))
@@ -4376,6 +4657,320 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, UpdateProfileError::Network(_)));
+    }
+
+    #[tokio::test]
+    async fn request_phone_verification_sends_the_bearer_token_and_returns_no_data() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/phone/verification"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .request_phone_verification(&sample_token())
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.data, ());
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn request_phone_verification_returns_rate_limited_on_429_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/phone/verification"))
+            .respond_with(ResponseTemplate::new(429).set_body_json(serde_json::json!({
+                "message": "Too Many Attempts.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .request_phone_verification(&sample_token())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, RequestPhoneVerificationError::RateLimited);
+    }
+
+    #[tokio::test]
+    async fn request_phone_verification_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/phone/verification"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/phone/verification"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .request_phone_verification(&sample_token())
+            .await
+            .unwrap();
+
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn request_phone_verification_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/phone/verification"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .request_phone_verification(&sample_token())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, RequestPhoneVerificationError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn request_phone_verification_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .request_phone_verification(&sample_token())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RequestPhoneVerificationError::Network(_)));
+    }
+
+    #[tokio::test]
+    async fn confirm_phone_verification_rejects_an_empty_code_without_sending_a_request() {
+        let client = ApiClient::new("https://unreachable.invalid");
+
+        assert_eq!(
+            client
+                .confirm_phone_verification(&sample_token(), "   ")
+                .await,
+            Err(ConfirmPhoneVerificationError::EmptyCode)
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_phone_verification_sends_the_trimmed_code_and_returns_the_updated_account() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/phone/verification/confirm"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .and(body_json(serde_json::json!({ "code": "482913" })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "id": 1,
+                    "name": "Ana Garcia",
+                    "email": "ana@example.com",
+                    "phone": "+573001234567",
+                    "phone_verified": true,
+                    "role": "passenger",
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .confirm_phone_verification(&sample_token(), "  482913  ")
+            .await
+            .unwrap();
+
+        assert!(fetch.data.phone_verified);
+        assert_eq!(fetch.refreshed_token, None);
+    }
+
+    #[tokio::test]
+    async fn confirm_phone_verification_returns_validation_error_on_422_without_retrying() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/phone/verification/confirm"))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "message": "El codigo no es correcto.",
+                "errors": {
+                    "code": ["El codigo no es correcto."],
+                },
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .confirm_phone_verification(&sample_token(), "000000")
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            ConfirmPhoneVerificationError::Validation(ApiErrorBody {
+                message: "El codigo no es correcto.".to_string(),
+                errors: Some(HashMap::from([(
+                    "code".to_string(),
+                    vec!["El codigo no es correcto.".to_string()]
+                )])),
+            })
+        );
+        assert_eq!(
+            error.field_message("code"),
+            Some("El codigo no es correcto.".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_phone_verification_refreshes_once_and_retries_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/phone/verification/confirm"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "access_token": "new-jwt-token",
+                    "token_type": "bearer",
+                    "expires_in": 900,
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/phone/verification/confirm"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer new-jwt-token",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "id": 1,
+                    "name": "Ana Garcia",
+                    "email": "ana@example.com",
+                    "phone": "+573001234567",
+                    "phone_verified": true,
+                    "role": "passenger",
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let fetch = client
+            .confirm_phone_verification(&sample_token(), "482913")
+            .await
+            .unwrap();
+
+        assert!(fetch.data.phone_verified);
+        assert_eq!(fetch.refreshed_token.unwrap().access_token, "new-jwt-token");
+    }
+
+    #[tokio::test]
+    async fn confirm_phone_verification_forces_session_expired_when_the_token_cannot_be_renewed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/me/phone/verification/confirm"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "Unauthenticated.",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/auth/refresh"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "message": "El token no es valido o ya expiro.",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri());
+        let error = client
+            .confirm_phone_verification(&sample_token(), "482913")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, ConfirmPhoneVerificationError::SessionExpired);
+    }
+
+    #[tokio::test]
+    async fn confirm_phone_verification_returns_network_error_when_server_is_unreachable() {
+        let client = ApiClient::new("http://127.0.0.1:1");
+
+        let error = client
+            .confirm_phone_verification(&sample_token(), "482913")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ConfirmPhoneVerificationError::Network(_)));
     }
 
     #[tokio::test]

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -22,6 +22,10 @@ pub struct User {
     pub name: String,
     pub email: String,
     pub phone: String,
+    /// Si el celular ya se confirmo con un codigo por SMS (issue #69 del
+    /// backend). Ver `ApiClient::request_phone_verification` y
+    /// `ApiClient::confirm_phone_verification`.
+    pub phone_verified: bool,
     pub role: Role,
 }
 
@@ -106,6 +110,12 @@ pub struct UpdateProfilePayload {
     pub email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub phone: Option<String>,
+}
+
+/// Body de `POST /api/v1/me/phone/verification/confirm`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ConfirmPhoneVerificationPayload {
+    pub code: String,
 }
 
 /// Body de `POST /api/v1/me/vehicle`
@@ -515,6 +525,7 @@ mod tests {
                     "name": "Ana Garcia",
                     "email": "ana@example.com",
                     "phone": "+573001234567",
+                    "phone_verified": false,
                     "role": "passenger"
                 },
                 "token": {

--- a/crates/moto_core/src/state.rs
+++ b/crates/moto_core/src/state.rs
@@ -146,6 +146,7 @@ mod tests {
                 name: "Ana Garcia".to_string(),
                 email: "ana@example.com".to_string(),
                 phone: "+573001234567".to_string(),
+                phone_verified: false,
                 role: Role::Passenger,
             },
             token: AuthToken {

--- a/crates/moto_ui/src/screens/profile.rs
+++ b/crates/moto_ui/src/screens/profile.rs
@@ -9,11 +9,22 @@
 //! La edicion (issue #10) reusa esta misma pantalla en vez de ser una
 //! pantalla aparte: el formulario se precarga con `session.user()` y, al
 //! guardar, llama a `ApiClient::update_profile` (`PATCH /api/v1/me`).
+//!
+//! La verificacion del celular (issue #69 del backend) tambien vive aca y no
+//! en una pantalla propia, mismo criterio que la edicion: es un dato mas de
+//! la cuenta, no una seccion de navegacion aparte. `PhoneVerificationSection`
+//! solo se muestra cuando `user.phone_verified` es `false`; al confirmar el
+//! codigo, `session.set_user()` deja `phone_verified` en `true` y la propia
+//! reactividad de Dioxus hace que la seccion desaparezca sin ningun callback
+//! explicito.
 
 use std::sync::Arc;
 
 use dioxus::prelude::*;
-use moto_core::api::{ApiClient, AuthenticatedRequestError, UpdateProfileError};
+use moto_core::api::{
+    ApiClient, AuthenticatedRequestError, ConfirmPhoneVerificationError,
+    RequestPhoneVerificationError, UpdateProfileError,
+};
 use moto_core::models::{Role, UpdateProfilePayload, User};
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
@@ -100,9 +111,20 @@ pub fn ProfileScreen() -> Element {
                         dt { "Email" }
                         dd { "{user.email}" }
                         dt { "Telefono" }
-                        dd { "{user.phone}" }
+                        dd {
+                            "{user.phone}"
+                            " "
+                            if user.phone_verified {
+                                span { class: "profile-phone-verified", "(verificado)" }
+                            } else {
+                                span { class: "profile-phone-unverified", "(sin verificar)" }
+                            }
+                        }
                         dt { "Rol" }
                         dd { "{role_label(user.role)}" }
+                    }
+                    if !user.phone_verified {
+                        PhoneVerificationSection {}
                     }
                     button {
                         r#type: "button",
@@ -253,6 +275,176 @@ fn EditProfileForm(props: EditProfileFormProps) -> Element {
         }
         if let Some(message) = general_message {
             p { class: "profile-edit-error", role: "alert", "{message}" }
+        }
+    }
+}
+
+/// Flujo de verificacion de celular por SMS (issue #69 del backend). Sin
+/// props: lee la cuenta y el token del mismo `SessionState` del contexto, y
+/// al confirmar deja el `User` actualizado ahi mismo, mismo criterio que
+/// `EditProfileForm`.
+///
+/// Dos pasos con el mismo signal `code_requested` como bandera: mientras es
+/// `false` solo hay un boton para pedir el codigo; una vez pedido, aparece el
+/// formulario para confirmarlo. "Reenviar codigo" reutiliza el mismo pedido
+/// que el boton inicial — el backend reemplaza cualquier codigo vigente en
+/// vez de acumularlo (ver `Back_App_MotoCarros`), asi que no hace falta
+/// distinguir un primer pedido de un reenvio.
+#[component]
+fn PhoneVerificationSection() -> Element {
+    let api_client = use_context::<ApiClient>();
+    let storage = use_context::<Arc<dyn TokenStorage>>();
+    let mut session = use_context::<SessionState>();
+
+    let mut code_requested = use_signal(|| false);
+    let mut code = use_signal(String::new);
+    let mut is_requesting = use_signal(|| false);
+    let mut is_confirming = use_signal(|| false);
+    let mut request_error = use_signal(|| None::<RequestPhoneVerificationError>);
+    let mut confirm_error = use_signal(|| None::<ConfirmPhoneVerificationError>);
+
+    let api_client_for_request = api_client.clone();
+    let storage_for_request = storage.clone();
+
+    let on_request = move |_| {
+        let Some(token) = session.token() else {
+            return;
+        };
+        let api_client = api_client_for_request.clone();
+        let storage = storage_for_request.clone();
+
+        spawn(async move {
+            is_requesting.set(true);
+            request_error.set(None);
+
+            match api_client.request_phone_verification(&token).await {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    code_requested.set(true);
+                }
+                Err(RequestPhoneVerificationError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    request_error.set(Some(err));
+                }
+            }
+
+            is_requesting.set(false);
+        });
+    };
+
+    let on_confirm = move |event: FormEvent| {
+        event.prevent_default();
+
+        let Some(token) = session.token() else {
+            return;
+        };
+        let code_value = code();
+        let api_client = api_client.clone();
+        let storage = storage.clone();
+
+        spawn(async move {
+            is_confirming.set(true);
+            confirm_error.set(None);
+
+            match api_client
+                .confirm_phone_verification(&token, &code_value)
+                .await
+            {
+                Ok(fetch) => {
+                    if let Some(refreshed) = fetch.refreshed_token {
+                        session.update_token(refreshed, storage.as_ref());
+                    }
+                    session.set_user(fetch.data);
+                }
+                Err(ConfirmPhoneVerificationError::SessionExpired) => {
+                    session.logout(storage.as_ref());
+                }
+                Err(err) => {
+                    confirm_error.set(Some(err));
+                }
+            }
+
+            is_confirming.set(false);
+        });
+    };
+
+    if !code_requested() {
+        let request_message = request_error().as_ref().map(|err| err.to_string());
+
+        return rsx! {
+            div { class: "phone-verification-section",
+                p { "Tu celular todavia no esta verificado." }
+                button {
+                    r#type: "button",
+                    disabled: is_requesting(),
+                    onclick: on_request,
+                    if is_requesting() {
+                        "Enviando codigo..."
+                    } else {
+                        "Verificar mi celular"
+                    }
+                }
+                if let Some(message) = request_message {
+                    p { class: "phone-verification-error", role: "alert", "{message}" }
+                }
+            }
+        };
+    }
+
+    let current_error = confirm_error();
+    let code_error = current_error
+        .as_ref()
+        .and_then(|err| err.field_message("code"));
+    // Igual que en el registro (issue #6): el mensaje generico solo se
+    // muestra cuando el error no trae desglose campo por campo.
+    let general_message = if code_error.is_some() {
+        None
+    } else {
+        current_error.as_ref().map(|err| err.to_string())
+    };
+
+    rsx! {
+        div { class: "phone-verification-section",
+            p { "Te enviamos un codigo por SMS. Ingresalo para confirmar tu celular." }
+            form { onsubmit: on_confirm,
+                label { r#for: "phone-verification-code", "Codigo" }
+                input {
+                    id: "phone-verification-code",
+                    r#type: "text",
+                    inputmode: "numeric",
+                    autocomplete: "one-time-code",
+                    disabled: is_confirming(),
+                    value: "{code}",
+                    oninput: move |event| code.set(event.value()),
+                }
+                if let Some(message) = &code_error {
+                    p { class: "phone-verification-field-error", role: "alert", "{message}" }
+                }
+                button { r#type: "submit", disabled: is_confirming(),
+                    if is_confirming() {
+                        "Confirmando..."
+                    } else {
+                        "Confirmar codigo"
+                    }
+                }
+            }
+            button {
+                r#type: "button",
+                disabled: is_requesting(),
+                onclick: on_request,
+                if is_requesting() {
+                    "Reenviando..."
+                } else {
+                    "Reenviar codigo"
+                }
+            }
+            if let Some(message) = general_message {
+                p { class: "phone-verification-error", role: "alert", "{message}" }
+            }
         }
     }
 }


### PR DESCRIPTION
## Resumen
- `ApiClient::request_phone_verification` / `ApiClient::confirm_phone_verification` en `moto_core`, consumiendo la historia #69 ya fusionada en `Back_App_MotoCarros`.
- `User.phone_verified: bool` agregado al modelo (el backend ya lo expone).
- `PhoneVerificationSection` dentro de `ProfileScreen`: pide el código, lo confirma, y desaparece sola cuando `phone_verified` pasa a `true` (reactividad de `SessionState`, sin callback explícito).

Closes #60

## Plan de pruebas
- [x] `cargo fmt --all -- --check` sin errores.
- [x] `cargo clippy --workspace --exclude mobile --all-targets --all-features -- -D warnings` sin errores.
- [x] `cargo test --workspace --exclude mobile` — 216 tests en `moto_core` + 20 en `moto_ui`, todos en verde.
- [x] `cargo build --package web --target wasm32-unknown-unknown` — build web en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)