### PR TITLE
feat(#64): cambiar el campo model del vehiculo por type (Motocarro/Motocarga)

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -11,7 +11,7 @@ use crate::models::{
     RegisterDriverPayload, RegisterPassengerPayload, RegisterVehiclePayload, Ride,
     RideCancellation, RideEstimate, RideEstimateRequestPayload, RideRating, RideReceipt,
     RideRequestPayload, UpdateProfilePayload, UpdateVehiclePayload, UploadedDriverDocument, User,
-    Vehicle,
+    Vehicle, VehicleType,
 };
 
 #[cfg(test)]
@@ -2226,14 +2226,13 @@ impl ApiClient {
         &self,
         token: &AuthToken,
         plate: &str,
-        model: &str,
+        vehicle_type: VehicleType,
         year: &str,
     ) -> Result<AuthenticatedFetch<Vehicle>, RegisterVehicleError> {
         let plate = plate.trim().to_uppercase();
-        let model = model.trim();
         let year = year.trim();
 
-        if plate.is_empty() || model.is_empty() || year.is_empty() {
+        if plate.is_empty() || year.is_empty() {
             return Err(RegisterVehicleError::EmptyFields);
         }
         if !is_valid_plate(&plate) {
@@ -2248,7 +2247,7 @@ impl ApiClient {
 
         let payload = RegisterVehiclePayload {
             plate,
-            model: model.to_string(),
+            vehicle_type,
             year: year_number,
         };
 
@@ -2410,10 +2409,10 @@ impl ApiClient {
         &self,
         token: &AuthToken,
         plate: Option<&str>,
-        model: Option<&str>,
+        vehicle_type: Option<VehicleType>,
         year: Option<&str>,
     ) -> Result<AuthenticatedFetch<Vehicle>, UpdateVehicleError> {
-        if plate.is_none() && model.is_none() && year.is_none() {
+        if plate.is_none() && vehicle_type.is_none() && year.is_none() {
             return Err(UpdateVehicleError::NoFields);
         }
 
@@ -2427,7 +2426,6 @@ impl ApiClient {
             }
             None => None,
         };
-        let model = model.map(|value| value.trim().to_string());
         let year = match year {
             Some(value) => {
                 let Ok(year_number) = value.trim().parse::<u16>() else {
@@ -2441,7 +2439,11 @@ impl ApiClient {
             None => None,
         };
 
-        let payload = UpdateVehiclePayload { plate, model, year };
+        let payload = UpdateVehiclePayload {
+            plate,
+            vehicle_type,
+            year,
+        };
 
         match self
             .patch_vehicle_with_token(&token.access_token, &payload)
@@ -5465,19 +5467,13 @@ mod tests {
 
         assert_eq!(
             client
-                .register_vehicle(&sample_token(), "", "Bajaj Boxer CT 100", "2022")
+                .register_vehicle(&sample_token(), "", VehicleType::Motocarro, "2022")
                 .await,
             Err(RegisterVehicleError::EmptyFields)
         );
         assert_eq!(
             client
-                .register_vehicle(&sample_token(), "ABC12D", "", "2022")
-                .await,
-            Err(RegisterVehicleError::EmptyFields)
-        );
-        assert_eq!(
-            client
-                .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "")
+                .register_vehicle(&sample_token(), "ABC12D", VehicleType::Motocarro, "")
                 .await,
             Err(RegisterVehicleError::EmptyFields)
         );
@@ -5489,13 +5485,13 @@ mod tests {
 
         assert_eq!(
             client
-                .register_vehicle(&sample_token(), "AB", "Bajaj Boxer CT 100", "2022")
+                .register_vehicle(&sample_token(), "AB", VehicleType::Motocarro, "2022")
                 .await,
             Err(RegisterVehicleError::InvalidPlate)
         );
         assert_eq!(
             client
-                .register_vehicle(&sample_token(), "ABC 12D!", "Bajaj Boxer CT 100", "2022")
+                .register_vehicle(&sample_token(), "ABC 12D!", VehicleType::Motocarro, "2022")
                 .await,
             Err(RegisterVehicleError::InvalidPlate)
         );
@@ -5510,7 +5506,7 @@ mod tests {
                 .register_vehicle(
                     &sample_token(),
                     "ABC12D",
-                    "Bajaj Boxer CT 100",
+                    VehicleType::Motocarro,
                     "not-a-year"
                 )
                 .await,
@@ -5518,7 +5514,7 @@ mod tests {
         );
         assert_eq!(
             client
-                .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "1969")
+                .register_vehicle(&sample_token(), "ABC12D", VehicleType::Motocarro, "1969")
                 .await,
             Err(RegisterVehicleError::InvalidYear)
         );
@@ -5536,13 +5532,13 @@ mod tests {
             ))
             .and(body_json(serde_json::json!({
                 "plate": "ABC12D",
-                "model": "Bajaj Boxer CT 100",
+                "type": "motocarro",
                 "year": 2022,
             })))
             .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
                 "data": {
                     "plate": "ABC12D",
-                    "model": "Bajaj Boxer CT 100",
+                    "type": "motocarro",
                     "year": 2022,
                 }
             })))
@@ -5551,7 +5547,7 @@ mod tests {
 
         let client = ApiClient::new(server.uri());
         let fetch = client
-            .register_vehicle(&sample_token(), " abc12d ", "Bajaj Boxer CT 100", "2022")
+            .register_vehicle(&sample_token(), " abc12d ", VehicleType::Motocarro, "2022")
             .await
             .unwrap();
 
@@ -5574,7 +5570,7 @@ mod tests {
 
         let client = ApiClient::new(server.uri());
         let error = client
-            .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "2022")
+            .register_vehicle(&sample_token(), "ABC12D", VehicleType::Motocarro, "2022")
             .await
             .unwrap_err();
 
@@ -5599,7 +5595,7 @@ mod tests {
 
         let client = ApiClient::new(server.uri());
         let error = client
-            .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "2022")
+            .register_vehicle(&sample_token(), "ABC12D", VehicleType::Motocarro, "2022")
             .await
             .unwrap_err();
 
@@ -5661,7 +5657,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
                 "data": {
                     "plate": "ABC12D",
-                    "model": "Bajaj Boxer CT 100",
+                    "type": "motocarro",
                     "year": 2022,
                 }
             })))
@@ -5670,7 +5666,7 @@ mod tests {
 
         let client = ApiClient::new(server.uri());
         let fetch = client
-            .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "2022")
+            .register_vehicle(&sample_token(), "ABC12D", VehicleType::Motocarro, "2022")
             .await
             .unwrap();
 
@@ -5700,7 +5696,7 @@ mod tests {
 
         let client = ApiClient::new(server.uri());
         let error = client
-            .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "2022")
+            .register_vehicle(&sample_token(), "ABC12D", VehicleType::Motocarro, "2022")
             .await
             .unwrap_err();
 
@@ -5712,7 +5708,7 @@ mod tests {
         let client = ApiClient::new("http://127.0.0.1:1");
 
         let error = client
-            .register_vehicle(&sample_token(), "ABC12D", "Bajaj Boxer CT 100", "2022")
+            .register_vehicle(&sample_token(), "ABC12D", VehicleType::Motocarro, "2022")
             .await
             .unwrap_err();
 
@@ -5732,7 +5728,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "data": {
                     "plate": "ABC12D",
-                    "model": "Bajaj Boxer CT 100",
+                    "type": "motocarro",
                     "year": 2022,
                 }
             })))
@@ -5824,7 +5820,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "data": {
                     "plate": "ABC12D",
-                    "model": "Bajaj Boxer CT 100",
+                    "type": "motocarro",
                     "year": 2022,
                 }
             })))
@@ -5931,7 +5927,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "data": {
                     "plate": "ABC12D",
-                    "model": "Bajaj Boxer CT 100",
+                    "type": "motocarro",
                     "year": 2022,
                 }
             })))
@@ -6047,7 +6043,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "data": {
                     "plate": "ABC12D",
-                    "model": "Bajaj Boxer CT 100",
+                    "type": "motocarro",
                     "year": 2022,
                 }
             })))

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -182,6 +182,17 @@ pub struct UploadedDriverDocument {
     pub uploaded_at: String,
 }
 
+/// Categoria del vehiculo (`openapi.yaml#/components/schemas/Vehicle`,
+/// historia tecnica #75 del backend). Reemplaza el antiguo campo `model`
+/// (texto libre): el anio ya identifica el modelo puntual, y lo que importa
+/// operativamente es si el vehiculo es un motocarro o una motocarga.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum VehicleType {
+    Motocarro,
+    Motocarga,
+}
+
 /// Body de `POST /api/v1/me/vehicle`
 /// (`openapi.yaml#/components/schemas/VehicleRegistrationRequest`).
 ///
@@ -192,7 +203,8 @@ pub struct UploadedDriverDocument {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct RegisterVehiclePayload {
     pub plate: String,
-    pub model: String,
+    #[serde(rename = "type")]
+    pub vehicle_type: VehicleType,
     pub year: u16,
 }
 
@@ -204,7 +216,8 @@ pub struct RegisterVehiclePayload {
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Vehicle {
     pub plate: String,
-    pub model: String,
+    #[serde(rename = "type")]
+    pub vehicle_type: VehicleType,
     pub year: u16,
 }
 
@@ -218,8 +231,8 @@ pub struct Vehicle {
 pub struct UpdateVehiclePayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plate: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub vehicle_type: Option<VehicleType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub year: Option<u16>,
 }
@@ -640,10 +653,10 @@ mod tests {
     }
 
     #[test]
-    fn register_vehicle_payload_serializes_plate_model_and_year() {
+    fn register_vehicle_payload_serializes_plate_type_and_year() {
         let payload = RegisterVehiclePayload {
             plate: "ABC12D".to_string(),
-            model: "Bajaj Boxer CT 100".to_string(),
+            vehicle_type: VehicleType::Motocarro,
             year: 2022,
         };
 
@@ -653,7 +666,7 @@ mod tests {
             json,
             serde_json::json!({
                 "plate": "ABC12D",
-                "model": "Bajaj Boxer CT 100",
+                "type": "motocarro",
                 "year": 2022,
             })
         );
@@ -664,7 +677,7 @@ mod tests {
         let json = r#"{
             "data": {
                 "plate": "ABC12D",
-                "model": "Bajaj Boxer CT 100",
+                "type": "motocarro",
                 "year": 2022
             }
         }"#;
@@ -672,7 +685,7 @@ mod tests {
         let envelope: DataEnvelope<Vehicle> = serde_json::from_str(json).unwrap();
 
         assert_eq!(envelope.data.plate, "ABC12D");
-        assert_eq!(envelope.data.model, "Bajaj Boxer CT 100");
+        assert_eq!(envelope.data.vehicle_type, VehicleType::Motocarro);
         assert_eq!(envelope.data.year, 2022);
     }
 

--- a/crates/moto_ui/src/screens/register_vehicle.rs
+++ b/crates/moto_ui/src/screens/register_vehicle.rs
@@ -17,9 +17,23 @@ use std::sync::Arc;
 
 use dioxus::prelude::*;
 use moto_core::api::{ApiClient, RegisterVehicleError};
-use moto_core::models::Vehicle;
+use moto_core::models::{Vehicle, VehicleType};
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
+
+fn vehicle_type_label(vehicle_type: VehicleType) -> &'static str {
+    match vehicle_type {
+        VehicleType::Motocarro => "Motocarro",
+        VehicleType::Motocarga => "Motocarga",
+    }
+}
+
+fn vehicle_type_slug(vehicle_type: VehicleType) -> &'static str {
+    match vehicle_type {
+        VehicleType::Motocarro => "motocarro",
+        VehicleType::Motocarga => "motocarga",
+    }
+}
 
 #[component]
 pub fn RegisterVehicleScreen() -> Element {
@@ -28,7 +42,7 @@ pub fn RegisterVehicleScreen() -> Element {
     let mut session = use_context::<SessionState>();
 
     let mut plate = use_signal(String::new);
-    let mut model = use_signal(String::new);
+    let mut vehicle_type = use_signal(|| VehicleType::Motocarro);
     let mut year = use_signal(String::new);
     let mut register_error = use_signal(|| None::<RegisterVehicleError>);
     let mut is_loading = use_signal(|| false);
@@ -41,7 +55,7 @@ pub fn RegisterVehicleScreen() -> Element {
             return;
         };
         let plate_value = plate();
-        let model_value = model();
+        let vehicle_type_value = vehicle_type();
         let year_value = year();
         let api_client = api_client.clone();
         let storage = storage.clone();
@@ -51,7 +65,7 @@ pub fn RegisterVehicleScreen() -> Element {
             register_error.set(None);
 
             match api_client
-                .register_vehicle(&token, &plate_value, &model_value, &year_value)
+                .register_vehicle(&token, &plate_value, vehicle_type_value, &year_value)
                 .await
             {
                 Ok(fetch) => {
@@ -79,8 +93,8 @@ pub fn RegisterVehicleScreen() -> Element {
                 dl { class: "register-vehicle-result",
                     dt { "Placa" }
                     dd { "{vehicle.plate}" }
-                    dt { "Modelo" }
-                    dd { "{vehicle.model}" }
+                    dt { "Tipo" }
+                    dd { "{vehicle_type_label(vehicle.vehicle_type)}" }
                     dt { "Anio" }
                     dd { "{vehicle.year}" }
                 }
@@ -92,9 +106,9 @@ pub fn RegisterVehicleScreen() -> Element {
     let plate_error = current_error
         .as_ref()
         .and_then(|err| err.field_message("plate"));
-    let model_error = current_error
+    let type_error = current_error
         .as_ref()
-        .and_then(|err| err.field_message("model"));
+        .and_then(|err| err.field_message("type"));
     let year_error = current_error
         .as_ref()
         .and_then(|err| err.field_message("year"));
@@ -102,7 +116,7 @@ pub fn RegisterVehicleScreen() -> Element {
     // solo se muestra cuando el error no trae desglose campo por campo. Esto
     // tambien cubre el caso de vehiculo duplicado (422 bajo la clave
     // sintetica `vehicle`, que no coincide con ningun campo del formulario).
-    let has_field_errors = plate_error.is_some() || model_error.is_some() || year_error.is_some();
+    let has_field_errors = plate_error.is_some() || type_error.is_some() || year_error.is_some();
     let general_message = if has_field_errors {
         None
     } else {
@@ -125,16 +139,24 @@ pub fn RegisterVehicleScreen() -> Element {
                 if let Some(message) = &plate_error {
                     p { class: "register-vehicle-field-error", role: "alert", "{message}" }
                 }
-                label { r#for: "register-vehicle-model", "Modelo" }
-                input {
-                    id: "register-vehicle-model",
-                    r#type: "text",
-                    autocomplete: "off",
+                label { r#for: "register-vehicle-type", "Tipo" }
+                select {
+                    id: "register-vehicle-type",
                     disabled: is_loading(),
-                    value: "{model}",
-                    oninput: move |event| model.set(event.value()),
+                    value: "{vehicle_type_slug(vehicle_type())}",
+                    onchange: move |event| {
+                        vehicle_type
+                            .set(
+                                match event.value().as_str() {
+                                    "motocarga" => VehicleType::Motocarga,
+                                    _ => VehicleType::Motocarro,
+                                },
+                            )
+                    },
+                    option { value: "motocarro", "Motocarro" }
+                    option { value: "motocarga", "Motocarga" }
                 }
-                if let Some(message) = &model_error {
+                if let Some(message) = &type_error {
                     p { class: "register-vehicle-field-error", role: "alert", "{message}" }
                 }
                 label { r#for: "register-vehicle-year", "Anio" }

--- a/crates/moto_ui/src/screens/vehicle.rs
+++ b/crates/moto_ui/src/screens/vehicle.rs
@@ -15,11 +15,25 @@ use std::sync::Arc;
 
 use dioxus::prelude::*;
 use moto_core::api::{ApiClient, GetVehicleError, UpdateVehicleError};
-use moto_core::models::Vehicle;
+use moto_core::models::{Vehicle, VehicleType};
 use moto_core::state::SessionState;
 use moto_core::storage::TokenStorage;
 
 use super::register_vehicle::RegisterVehicleScreen;
+
+fn vehicle_type_label(vehicle_type: VehicleType) -> &'static str {
+    match vehicle_type {
+        VehicleType::Motocarro => "Motocarro",
+        VehicleType::Motocarga => "Motocarga",
+    }
+}
+
+fn vehicle_type_slug(vehicle_type: VehicleType) -> &'static str {
+    match vehicle_type {
+        VehicleType::Motocarro => "motocarro",
+        VehicleType::Motocarga => "motocarga",
+    }
+}
 
 #[component]
 pub fn VehicleScreen() -> Element {
@@ -96,7 +110,7 @@ struct EditVehicleFormProps {
     vehicle: Vehicle,
 }
 
-/// Formulario de edicion de placa/modelo/anio — issue #12. Precargado con
+/// Formulario de edicion de placa/tipo/anio — issue #12. Precargado con
 /// `props.vehicle`; al guardar manda los tres campos a
 /// `ApiClient::update_vehicle` (PATCH parcial, mismo criterio que
 /// `EditProfileForm` en `profile.rs`: el formulario siempre esta
@@ -108,7 +122,7 @@ fn EditVehicleForm(props: EditVehicleFormProps) -> Element {
     let mut session = use_context::<SessionState>();
 
     let mut plate = use_signal(|| props.vehicle.plate.clone());
-    let mut model = use_signal(|| props.vehicle.model.clone());
+    let mut vehicle_type = use_signal(|| props.vehicle.vehicle_type);
     let mut year = use_signal(|| props.vehicle.year.to_string());
     let mut update_error = use_signal(|| None::<UpdateVehicleError>);
     let mut is_saving = use_signal(|| false);
@@ -121,7 +135,7 @@ fn EditVehicleForm(props: EditVehicleFormProps) -> Element {
             return;
         };
         let plate_value = plate();
-        let model_value = model();
+        let vehicle_type_value = vehicle_type();
         let year_value = year();
         let api_client = api_client.clone();
         let storage = storage.clone();
@@ -134,7 +148,7 @@ fn EditVehicleForm(props: EditVehicleFormProps) -> Element {
                 .update_vehicle(
                     &token,
                     Some(&plate_value),
-                    Some(&model_value),
+                    Some(vehicle_type_value),
                     Some(&year_value),
                 )
                 .await
@@ -161,15 +175,15 @@ fn EditVehicleForm(props: EditVehicleFormProps) -> Element {
     let plate_error = current_error
         .as_ref()
         .and_then(|err| err.field_message("plate"));
-    let model_error = current_error
+    let type_error = current_error
         .as_ref()
-        .and_then(|err| err.field_message("model"));
+        .and_then(|err| err.field_message("type"));
     let year_error = current_error
         .as_ref()
         .and_then(|err| err.field_message("year"));
     // Igual que en `EditProfileForm` (issue #10): el mensaje generico solo
     // se muestra cuando el error no trae desglose campo por campo.
-    let has_field_errors = plate_error.is_some() || model_error.is_some() || year_error.is_some();
+    let has_field_errors = plate_error.is_some() || type_error.is_some() || year_error.is_some();
     let general_message = if has_field_errors {
         None
     } else {
@@ -183,8 +197,8 @@ fn EditVehicleForm(props: EditVehicleFormProps) -> Element {
                 dl { class: "update-vehicle-result",
                     dt { "Placa" }
                     dd { "{vehicle.plate}" }
-                    dt { "Modelo" }
-                    dd { "{vehicle.model}" }
+                    dt { "Tipo" }
+                    dd { "{vehicle_type_label(vehicle.vehicle_type)}" }
                     dt { "Anio" }
                     dd { "{vehicle.year}" }
                 }
@@ -202,16 +216,24 @@ fn EditVehicleForm(props: EditVehicleFormProps) -> Element {
                     if let Some(message) = &plate_error {
                         p { class: "update-vehicle-field-error", role: "alert", "{message}" }
                     }
-                    label { r#for: "update-vehicle-model", "Modelo" }
-                    input {
-                        id: "update-vehicle-model",
-                        r#type: "text",
-                        autocomplete: "off",
+                    label { r#for: "update-vehicle-type", "Tipo" }
+                    select {
+                        id: "update-vehicle-type",
                         disabled: is_saving(),
-                        value: "{model}",
-                        oninput: move |event| model.set(event.value()),
+                        value: "{vehicle_type_slug(vehicle_type())}",
+                        onchange: move |event| {
+                            vehicle_type
+                                .set(
+                                    match event.value().as_str() {
+                                        "motocarga" => VehicleType::Motocarga,
+                                        _ => VehicleType::Motocarro,
+                                    },
+                                )
+                        },
+                        option { value: "motocarro", "Motocarro" }
+                        option { value: "motocarga", "Motocarga" }
                     }
-                    if let Some(message) = &model_error {
+                    if let Some(message) = &type_error {
                         p { class: "update-vehicle-field-error", role: "alert", "{message}" }
                     }
                     label { r#for: "update-vehicle-year", "Anio" }


### PR DESCRIPTION
## Resumen
Refleja en la app el cambio del backend (`Back_App_MotoCarros#75`): el campo del vehículo pasa de `model` (texto libre) a `type`, con dos valores fijos: `motocarro` y `motocarga`.

- `moto_core::models`: nuevo enum `VehicleType` (serializa/deserializa como `"type"` en el JSON, mismo patrón que `DocumentType`/`DriverDocumentStatus`); `RegisterVehiclePayload`, `Vehicle` y `UpdateVehiclePayload` lo usan en vez de `model: String`.
- `moto_core::api`: `register_vehicle`/`update_vehicle` reciben `VehicleType` en vez de un `&str` libre; se elimina la validación de "campo de texto vacío" que ya no aplica a un enum.
- `moto_ui`: `RegisterVehicleScreen` y `VehicleScreen` (edición) muestran un `<select>` con las dos opciones fijas en vez de un input de texto libre.

## Plan de pruebas
- [x] `cargo test -p moto_core` — 226/226 verdes
- [x] `cargo build -p moto_ui` — verde
- [x] `cargo build -p web --target wasm32-unknown-unknown` — verde
- [x] `cargo fmt --check` — verde
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- [x] Probado manualmente en el navegador contra el backend local: registrar, consultar y editar un vehículo con ambos valores de tipo funciona de punta a punta

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)