### PR TITLE
feat(#66): reflejar la foto del vehiculo como tercer documento obligatorio

### DIFF
--- a/crates/moto_core/src/api.rs
+++ b/crates/moto_core/src/api.rs
@@ -2169,6 +2169,7 @@ impl ApiClient {
         let type_value = match document_type {
             DocumentType::Identidad => "identidad",
             DocumentType::TarjetaPropiedad => "tarjeta_propiedad",
+            DocumentType::FotoVehiculo => "foto_vehiculo",
         };
 
         let mut file_part = reqwest::multipart::Part::bytes(bytes).file_name(file_name.to_string());

--- a/crates/moto_core/src/models.rs
+++ b/crates/moto_core/src/models.rs
@@ -121,6 +121,10 @@ pub struct ConfirmPhoneVerificationPayload {
 /// Tipo de documento de verificacion del conductor
 /// (`openapi.yaml#/components/schemas/DriverDocument` de `Back_App_MotoCarros`).
 ///
+/// `FotoVehiculo` es antifraude (historia tecnica #75 del backend), no de
+/// identidad: la tarjeta de propiedad por si sola no prueba que corresponda
+/// al vehiculo fisico que el conductor realmente opera.
+///
 /// Licencia de conduccion y SOAT no son obligatorios todavia (decision de
 /// negocio explicita del backend) y por eso no tienen variante aca: agregar
 /// una sin que el backend la exija se romperia contra la lista real de
@@ -130,6 +134,7 @@ pub struct ConfirmPhoneVerificationPayload {
 pub enum DocumentType {
     Identidad,
     TarjetaPropiedad,
+    FotoVehiculo,
 }
 
 /// Estado de revision de un documento de verificacion.

--- a/crates/moto_ui/src/screens/documents.rs
+++ b/crates/moto_ui/src/screens/documents.rs
@@ -27,6 +27,7 @@ fn document_type_label(document_type: DocumentType) -> &'static str {
     match document_type {
         DocumentType::Identidad => "Documento de identidad (cedula, cedula de extranjeria o PTP)",
         DocumentType::TarjetaPropiedad => "Tarjeta de propiedad del motocarro",
+        DocumentType::FotoVehiculo => "Foto del vehiculo",
     }
 }
 
@@ -34,6 +35,7 @@ fn document_type_slug(document_type: DocumentType) -> &'static str {
     match document_type {
         DocumentType::Identidad => "identidad",
         DocumentType::TarjetaPropiedad => "tarjeta-propiedad",
+        DocumentType::FotoVehiculo => "foto-vehiculo",
     }
 }
 


### PR DESCRIPTION
## Resumen
Refleja el tercer documento obligatorio del backend (`Back_App_MotoCarros#78`): `moto_core::models::DocumentType` gana la variante `FotoVehiculo` (serializa/deserializa como `"foto_vehiculo"`); `DocumentsScreen` la muestra como una tercera fila "Foto del vehículo" con su propio campo de subida, igual que las otras dos.

Cambio puramente aditivo (un nuevo `case` + 2 brazos de `match`) siguiendo el mismo patrón exacto de `Identidad`/`TarjetaPropiedad` ya existente — la exhaustividad de `match` que exige el compilador de Rust garantiza que no quedó ningún lugar sin actualizar.

## Nota sobre verificación local
`cargo test`/`cargo clippy` no pudieron correr en esta máquina de desarrollo: un `cargo clean` disparó una reconstrucción nativa de `aws-lc-sys` (dependencia de TLS de `reqwest`) que choca con un bug real y reproducible de `gcc` 16.2.0 (mingw) en este equipo — un `internal compiler error: Segmentation fault` compilando código C de terceros (`jitterentropy-*.c`), nada relacionado con este cambio. `cargo fmt --check` sí corrió y pasó. CI corre en Linux y no debería verse afectado por este problema específico de Windows/mingw.

## Plan de pruebas
- [x] `cargo fmt --all -- --check` — verde
- [x] Probado manualmente en el navegador contra el backend local: las tres filas (identidad, tarjeta de propiedad, foto del vehículo) aparecen correctamente en `/me/documents`
- [ ] `cargo test` / `cargo clippy` — pendientes de que corra en CI (ver nota arriba)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)